### PR TITLE
Refactor MediaStreamTrack and MediaStream

### DIFF
--- a/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
+++ b/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
@@ -4,11 +4,14 @@ import org.webrtc.AudioTrack
 
 actual class AudioStreamTrack internal constructor(
     android: AudioTrack,
-    private val onStop: () -> Unit = { },
+    private val onTrackStopped: () -> Unit = { },
 ) : MediaStreamTrack(android) {
 
-    override fun stop() {
-        onStop()
-        super.stop()
+    override fun onSetEnabled(enabled: Boolean) {
+        // ignore
+    }
+
+    override fun onStop() {
+        onTrackStopped()
     }
 }

--- a/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/MediaStreamTrack.kt
+++ b/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/MediaStreamTrack.kt
@@ -8,7 +8,7 @@ import org.webrtc.AudioTrack as AndroidAudioTrack
 import org.webrtc.MediaStreamTrack as AndroidMediaStreamTrack
 import org.webrtc.VideoTrack as AndroidVideoTrack
 
-actual open class MediaStreamTrack internal constructor(val android: AndroidMediaStreamTrack) {
+actual abstract class MediaStreamTrack internal constructor(val android: AndroidMediaStreamTrack) {
 
     actual val id: String
         get() = android.id()
@@ -37,6 +37,7 @@ actual open class MediaStreamTrack internal constructor(val android: AndroidMedi
         get() = android.enabled()
         set(value) {
             android.setEnabled(value)
+            onSetEnabled(value)
         }
 
     private val _onEnded = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
@@ -48,10 +49,15 @@ actual open class MediaStreamTrack internal constructor(val android: AndroidMedi
     // not implemented for Android
     actual val onUnmute: Flow<Unit> = emptyFlow()
 
-    actual open fun stop() {
+    actual fun stop() {
         if (readyState == MediaStreamTrackState.Ended) return
         _onEnded.tryEmit(Unit)
+        onStop()
     }
+
+    protected abstract fun onSetEnabled(enabled: Boolean)
+
+    protected abstract fun onStop()
 }
 
 internal fun AndroidMediaStreamTrack.asCommon(): MediaStreamTrack {

--- a/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/VideoStreamTrack.kt
+++ b/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/VideoStreamTrack.kt
@@ -6,7 +6,8 @@ import org.webrtc.VideoTrack
 actual class VideoStreamTrack internal constructor(
     android: VideoTrack,
     private val onSwitchCamera: suspend (String?) -> Unit = { },
-    private val onStop: () -> Unit = { },
+    private val onTrackSetEnabled: (Boolean) -> Unit = { },
+    private val onTrackStopped: () -> Unit = { },
 ) : MediaStreamTrack(android) {
 
     actual suspend fun switchCamera(deviceId: String?) {
@@ -21,8 +22,11 @@ actual class VideoStreamTrack internal constructor(
         (android as VideoTrack).removeSink(sink)
     }
 
-    override fun stop() {
-        onStop()
-        super.stop()
+    override fun onSetEnabled(enabled: Boolean) {
+        onTrackSetEnabled(enabled)
+    }
+
+    override fun onStop() {
+        onTrackStopped()
     }
 }

--- a/webrtc-kmp/src/commonMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
+++ b/webrtc-kmp/src/commonMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
@@ -1,15 +1,17 @@
 package com.shepeliev.webrtckmp
 
-expect class MediaStream {
+expect class MediaStream(tracks: List<MediaStreamTrack>) {
     val id: String
     val tracks: List<MediaStreamTrack>
-    val audioTracks: List<AudioStreamTrack>
-    val videoTracks: List<VideoStreamTrack>
 
-    fun addTrack(track: AudioStreamTrack)
-    fun addTrack(track: VideoStreamTrack)
+    fun addTrack(track: MediaStreamTrack)
     fun getTrackById(id: String): MediaStreamTrack?
-    fun removeTrack(track: AudioStreamTrack)
-    fun removeTrack(track: VideoStreamTrack)
+    fun removeTrack(track: MediaStreamTrack)
     fun release()
 }
+
+val MediaStream.audioTracks: List<AudioStreamTrack>
+    get() = tracks.mapNotNull { it as? AudioStreamTrack }
+
+val MediaStream.videoTracks: List<VideoStreamTrack>
+    get() = tracks.mapNotNull { it as? VideoStreamTrack }

--- a/webrtc-kmp/src/commonMain/kotlin/com/shepeliev/webrtckmp/MediaStreamTrack.kt
+++ b/webrtc-kmp/src/commonMain/kotlin/com/shepeliev/webrtckmp/MediaStreamTrack.kt
@@ -2,7 +2,7 @@ package com.shepeliev.webrtckmp
 
 import kotlinx.coroutines.flow.Flow
 
-expect open class MediaStreamTrack {
+expect abstract class MediaStreamTrack {
     val id: String
     val kind: MediaStreamTrackKind
     val label: String

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
@@ -2,4 +2,13 @@ package com.shepeliev.webrtckmp
 
 import WebRTC.RTCAudioTrack
 
-actual class AudioStreamTrack internal constructor(ios: RTCAudioTrack) : MediaStreamTrack(ios)
+actual class AudioStreamTrack internal constructor(ios: RTCAudioTrack) : MediaStreamTrack(ios) {
+
+    override fun onSetEnabled(enabled: Boolean) {
+        // ignore
+    }
+
+    override fun onStop() {
+        // ignore
+    }
+}

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/MediaDevices.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/MediaDevices.kt
@@ -32,8 +32,17 @@ private object MediaDevicesImpl : MediaDevices {
                     ios = iosVideoTrack,
                     onSwitchCamera = { deviceId: String? ->
                         deviceId?.let { videoCaptureController.switchCamera(it) } ?: videoCaptureController.switchCamera()
-                    }
-                ) { videoCaptureController.stopCapture() }
+                    },
+                    onTrackSetEnabled = { enabled ->
+                        if (enabled) {
+                            videoCaptureController.initialize(videoSource)
+                            videoCaptureController.startCapture()
+                        } else {
+                            videoCaptureController.stopCapture()
+                        }
+                    } ,
+                    onTrackStopped = { videoCaptureController.stopCapture() }
+                )
                 videoCaptureController.initialize(videoSource)
                 videoCaptureController.startCapture()
                 videoTrack

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/MediaDevices.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/MediaDevices.kt
@@ -31,7 +31,8 @@ private object MediaDevicesImpl : MediaDevices {
                 val videoTrack = VideoStreamTrack(
                     ios = iosVideoTrack,
                     onSwitchCamera = { deviceId: String? ->
-                        deviceId?.let { videoCaptureController.switchCamera(it) } ?: videoCaptureController.switchCamera()
+                        deviceId?.let { videoCaptureController.switchCamera(it) }
+                            ?: videoCaptureController.switchCamera()
                     },
                     onTrackSetEnabled = { enabled ->
                         if (enabled) {
@@ -40,7 +41,7 @@ private object MediaDevicesImpl : MediaDevices {
                         } else {
                             videoCaptureController.stopCapture()
                         }
-                    } ,
+                    },
                     onTrackStopped = { videoCaptureController.stopCapture() }
                 )
                 videoCaptureController.initialize(videoSource)

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
@@ -7,39 +7,43 @@ import platform.Foundation.NSUUID
 
 actual class MediaStream internal constructor(
     val ios: RTCMediaStream?,
-    actual val id: String = ios?.streamId ?: NSUUID.UUID().UUIDString
+    actual val id: String = ios?.streamId ?: NSUUID.UUID().UUIDString,
+    tracks: List<MediaStreamTrack> = emptyList(),
 ) {
-    actual val tracks: List<MediaStreamTrack>
-        get() = audioTracks + videoTracks
 
-    private var audioTracksInternal = mutableListOf<AudioStreamTrack>()
-    actual val audioTracks: List<AudioStreamTrack> = audioTracksInternal
+    actual constructor(tracks: List<MediaStreamTrack>) : this(ios = null, tracks = tracks)
 
-    private var videoTracksInternal = mutableListOf<VideoStreamTrack>()
-    actual val videoTracks: List<VideoStreamTrack> = videoTracksInternal
+    private val _tracks = mutableListOf<MediaStreamTrack>()
+    actual val tracks: List<MediaStreamTrack> = _tracks
 
-    actual fun addTrack(track: AudioStreamTrack) {
-        ios?.addAudioTrack(track.ios as RTCAudioTrack)
-        audioTracksInternal += track
+    init {
+        _tracks += tracks
     }
 
-    actual fun addTrack(track: VideoStreamTrack) {
-        ios?.addVideoTrack(track.ios as RTCVideoTrack)
-        videoTracksInternal += track
+    actual fun addTrack(track: MediaStreamTrack) {
+        ios?.let {
+            when (track.ios) {
+                is RTCAudioTrack -> it.addAudioTrack(track.ios)
+                is RTCVideoTrack -> it.addVideoTrack(track.ios)
+                else -> error("Unknown MediaStreamTrack kind: ${track.kind}")
+            }
+        }
+        _tracks += track
     }
 
     actual fun getTrackById(id: String): MediaStreamTrack? {
         return tracks.firstOrNull { it.id == id }
     }
 
-    actual fun removeTrack(track: AudioStreamTrack) {
-        ios?.removeAudioTrack(track.ios as RTCAudioTrack)
-        audioTracksInternal -= track
-    }
-
-    actual fun removeTrack(track: VideoStreamTrack) {
-        ios?.removeVideoTrack(track.ios as RTCVideoTrack)
-        videoTracksInternal -= track
+    actual fun removeTrack(track: MediaStreamTrack) {
+        ios?.let {
+            when (track.ios) {
+                is RTCAudioTrack -> it.removeAudioTrack(track.ios)
+                is RTCVideoTrack -> it.removeVideoTrack(track.ios)
+                else -> error("Unknown MediaStreamTrack kind: ${track.kind}")
+            }
+        }
+        _tracks -= track
     }
 
     actual fun release() {

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/VideoStreamTrack.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/VideoStreamTrack.kt
@@ -6,7 +6,8 @@ import WebRTC.RTCVideoTrack
 actual class VideoStreamTrack internal constructor(
     ios: RTCVideoTrack,
     private val onSwitchCamera: (String?) -> Unit = { },
-    private val onStop: () -> Unit = { },
+    private val onTrackSetEnabled: (Boolean) -> Unit = { },
+    private val onTrackStopped: () -> Unit = { },
 ) : MediaStreamTrack(ios) {
 
     fun addRenderer(renderer: RTCVideoRendererProtocol) {
@@ -21,8 +22,11 @@ actual class VideoStreamTrack internal constructor(
         onSwitchCamera(deviceId)
     }
 
-    override fun stop() {
-        onStop()
-        super.stop()
+    override fun onSetEnabled(enabled: Boolean) {
+        onTrackSetEnabled(enabled)
+    }
+
+    override fun onStop() {
+        onTrackStopped()
     }
 }

--- a/webrtc-kmp/src/jsMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
+++ b/webrtc-kmp/src/jsMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
@@ -3,33 +3,22 @@ package com.shepeliev.webrtckmp
 import org.w3c.dom.mediacapture.MediaStream as JsMediaStream
 
 actual class MediaStream internal constructor(val js: JsMediaStream) {
+
+    actual constructor(tracks: List<MediaStreamTrack>) : this(JsMediaStream(tracks.map { it.js }.toTypedArray()))
+
     actual val id: String
         get() = js.id
 
     actual val tracks: List<MediaStreamTrack>
         get() = audioTracks + videoTracks
 
-    actual val audioTracks: List<AudioStreamTrack>
-        get() = js.getAudioTracks().map { AudioStreamTrack(it) }
-
-    actual val videoTracks: List<VideoStreamTrack>
-        get() = js.getVideoTracks().map { VideoStreamTrack(it) }
-
-    actual fun addTrack(track: AudioStreamTrack) {
-        js.addTrack(track.js)
-    }
-
-    actual fun addTrack(track: VideoStreamTrack) {
+    actual fun addTrack(track: MediaStreamTrack) {
         js.addTrack(track.js)
     }
 
     actual fun getTrackById(id: String): MediaStreamTrack? = js.getTrackById(id)?.asCommon()
 
-    actual fun removeTrack(track: AudioStreamTrack) {
-        js.removeTrack(track.js)
-    }
-
-    actual fun removeTrack(track: VideoStreamTrack) {
+    actual fun removeTrack(track: MediaStreamTrack) {
         js.removeTrack(track.js)
     }
 

--- a/webrtc-kmp/src/jsMain/kotlin/com/shepeliev/webrtckmp/MediaStreamTrack.kt
+++ b/webrtc-kmp/src/jsMain/kotlin/com/shepeliev/webrtckmp/MediaStreamTrack.kt
@@ -8,7 +8,7 @@ import org.w3c.dom.mediacapture.LIVE
 import org.w3c.dom.mediacapture.MediaStreamTrack as JsMediaStreamTrack
 import org.w3c.dom.mediacapture.MediaStreamTrackState as JsMediaStreamTrackState
 
-actual open class MediaStreamTrack internal constructor(val js: JsMediaStreamTrack) {
+actual abstract class MediaStreamTrack internal constructor(val js: JsMediaStreamTrack) {
     actual val id: String
         get() = js.id
 


### PR DESCRIPTION
- stop/start video capturing on setting video track disabled/enabled
- add `MediaStream(tracks: List<MediaStreamTrack>)` constructor
- add creating `MediaStream` at the `onTrack` event in case it is absent
