### PR TITLE
Desktop (JVM) support

### DIFF
--- a/buildSrc/src/main/kotlin/multiplatform-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiplatform-setup.gradle.kts
@@ -8,6 +8,8 @@ plugins {
 kotlin {
     android()
 
+    jvm()
+
     js {
         useCommonJs()
         browser()

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -20,6 +20,8 @@ decompose = "1.0.0-alpha-01"
 kermit = "1.1.2"
 firebaseBom = "30.3.1"
 
+webrtcJava = "0.7.0"
+
 [libraries]
 
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
@@ -50,3 +52,5 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-firestore = { module = "com.google.firebase:firebase-firestore-ktx" }
 
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
+
+webrtc-java = { module = "dev.onvoid.webrtc:webrtc-java", version.ref = "webrtcJava" }

--- a/webrtc-kmp/build.gradle.kts
+++ b/webrtc-kmp/build.gradle.kts
@@ -34,6 +34,8 @@ kotlin {
             }
         }
     }
+
+    jvm()
 }
 
 android {
@@ -49,6 +51,10 @@ dependencies {
     androidTestImplementation(deps.androidx.test.core)
     androidTestImplementation(deps.androidx.test.runner)
     jsMainImplementation(npm("webrtc-adapter", "8.1.1"))
+    jvmMainImplementation(deps.webrtc.java)
+    jvmMainImplementation(variantOf(deps.webrtc.java) { classifier("windows-x86_64") })
+    jvmMainImplementation(variantOf(deps.webrtc.java) { classifier("macos-x86_64") })
+    jvmMainImplementation(variantOf(deps.webrtc.java) { classifier("linux-x86_64") })
 }
 
 tasks.register<Download>("downloadAndroidWebRtc") {

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/VideoStreamTrack.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/VideoStreamTrack.kt
@@ -1,5 +1,6 @@
 package com.shepeliev.webrtckmp
 
+import WebRTC.CGSize
 import WebRTC.RTCVideoFrame
 import WebRTC.RTCVideoRendererProtocol
 import WebRTC.RTCVideoTrack
@@ -26,7 +27,8 @@ actual class VideoStreamTrack internal constructor(
 ) : MediaStreamTrack(ios) {
 
     // Setup track mute detector for remote tracks only.
-    private val trackMuteDetector = if (videoCaptureController == null) TrackMuteDetector() else null
+    private val trackMuteDetector =
+        if (videoCaptureController == null) TrackMuteDetector() else null
 
     init {
         videoCaptureController?.startCapture()
@@ -93,12 +95,20 @@ actual class VideoStreamTrack internal constructor(
                 dispatch_source_cancel(timer)
             }
 
-            timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue())
+            timer = dispatch_source_create(
+                type = DISPATCH_SOURCE_TYPE_TIMER,
+                handle = 0,
+                mask = 0,
+                queue = dispatch_get_main_queue(),
+            )
             dispatch_source_set_timer(
-                timer,
-                dispatch_time(DISPATCH_TIME_NOW, (INITIAL_MUTE_DELAY * NSEC_PER_SEC.toDouble()).toLong()),
-                (MUTE_DELAY * NSEC_PER_SEC.toDouble()).toULong(),
-                NSEC_PER_SEC / 10.toULong()
+                source = timer,
+                start = dispatch_time(
+                    DISPATCH_TIME_NOW,
+                    (INITIAL_MUTE_DELAY * NSEC_PER_SEC.toDouble()).toLong(),
+                ),
+                interval = (MUTE_DELAY * NSEC_PER_SEC.toDouble()).toULong(),
+                leeway = NSEC_PER_SEC / 10.toULong(),
             )
 
             var lastFrameCount = frameCount.value

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
@@ -3,7 +3,7 @@ package com.shepeliev.webrtckmp
 import dev.onvoid.webrtc.media.audio.AudioTrack
 
 actual class AudioStreamTrack internal constructor(
-    private val audioTrack: AudioTrack
+    private val audioTrack: AudioTrack,
 ) : MediaStreamTrack(native = audioTrack) {
 
     override fun onSetEnabled(enabled: Boolean) {

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
@@ -1,0 +1,16 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.media.audio.AudioTrack
+
+actual class AudioStreamTrack internal constructor(
+    private val audioTrack: AudioTrack
+) : MediaStreamTrack(native = audioTrack) {
+
+    override fun onSetEnabled(enabled: Boolean) {
+        // ignore
+    }
+
+    override fun onStop() {
+        audioTrack.dispose()
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/ByteBuffer.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/ByteBuffer.kt
@@ -1,0 +1,10 @@
+package com.shepeliev.webrtckmp
+
+import java.nio.ByteBuffer
+
+fun ByteBuffer.toByteArray(): ByteArray {
+    val bytes = ByteArray(remaining())
+    get(bytes)
+    rewind()
+    return bytes
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/CameraVideoCaptureController.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/CameraVideoCaptureController.kt
@@ -1,0 +1,70 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.media.MediaDevices
+import dev.onvoid.webrtc.media.video.VideoCapture
+import dev.onvoid.webrtc.media.video.VideoDevice
+import kotlin.math.abs
+
+internal class CameraVideoCaptureController(
+    private val constraints: VideoTrackConstraints,
+) : VideoCaptureController() {
+
+    private var currentDevice: VideoDevice? = null
+
+    override fun createVideoCapture(): VideoCapture {
+        selectDevice()
+        return VideoCapture().apply { setVideoCaptureDevice(currentDevice) }
+    }
+
+    private fun selectDevice() {
+        val devices = MediaDevices.getVideoCaptureDevices()
+
+        currentDevice = devices.firstOrNull { it.name == constraints.deviceId }
+            ?: throw CameraVideoCapturerException.notFound(constraints)
+    }
+
+    override fun selectVideoSize(): Size {
+        val requestedWidth = constraints.width?.exact
+            ?: constraints.width?.ideal
+            ?: DEFAULT_VIDEO_WIDTH
+
+        val requestedHeight = constraints.height?.exact
+            ?: constraints.height?.ideal
+            ?: DEFAULT_VIDEO_HEIGHT
+
+        val capabilities = MediaDevices.getVideoCaptureCapabilities(currentDevice)
+
+        val sizes = capabilities?.map { Size(it.width, it.height) } ?: emptyList()
+        if (sizes.isEmpty()) throw CameraVideoCapturerException.notFound(constraints)
+
+        return Size(
+            width = sizes.map { it.width }.closestValue(requestedWidth),
+            height = sizes.map { it.height }.closestValue(requestedHeight)
+        )
+    }
+
+    override fun selectFps(): Int {
+        val requestedFps = constraints.frameRate?.exact
+            ?: constraints.frameRate?.ideal
+            ?: DEFAULT_FRAME_RATE
+
+        val capabilities = MediaDevices.getVideoCaptureCapabilities(currentDevice)
+
+        val frameRates = capabilities?.map { it.frameRate } ?: emptyList()
+        if (frameRates.isEmpty()) throw CameraVideoCapturerException.notFound(constraints)
+
+        return frameRates.closestValue(requestedFps.toInt())
+    }
+
+    fun switchCamera() {
+        val devices = MediaDevices.getVideoCaptureDevices()
+        videoCapturer.setVideoCaptureDevice(devices.first { it != currentDevice })
+    }
+
+    fun switchCamera(deviceName: String) {
+        val devices = MediaDevices.getVideoCaptureDevices()
+        videoCapturer.setVideoCaptureDevice(devices.first { it.name == deviceName })
+    }
+}
+
+private fun List<Int>.closestValue(value: Int) = minBy { abs(value - it) }

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/CameraVideoCaptureController.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/CameraVideoCaptureController.kt
@@ -39,7 +39,7 @@ internal class CameraVideoCaptureController(
 
         return Size(
             width = sizes.map { it.width }.closestValue(requestedWidth),
-            height = sizes.map { it.height }.closestValue(requestedHeight)
+            height = sizes.map { it.height }.closestValue(requestedHeight),
         )
     }
 

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/DataChannel.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/DataChannel.kt
@@ -1,0 +1,98 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCDataChannel
+import dev.onvoid.webrtc.RTCDataChannelBuffer
+import dev.onvoid.webrtc.RTCDataChannelObserver
+import dev.onvoid.webrtc.RTCDataChannelState
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+import java.nio.ByteBuffer
+
+actual class DataChannel(private val jvm: RTCDataChannel) {
+
+    actual val label: String
+        get() = jvm.label
+
+    actual val id: Int
+        get() = jvm.id
+
+    actual val readyState: DataChannelState
+        get() = jvm.state.asCommon()
+
+    actual val bufferedAmount: Long
+        get() = jvm.bufferedAmount
+
+    private val dataChannelEvent = callbackFlow {
+        val observer = object : RTCDataChannelObserver {
+            override fun onBufferedAmountChange(p0: Long) {
+                // not implemented
+            }
+
+            override fun onStateChange() {
+                trySendBlocking(DataChannelEvent.StateChanged)
+            }
+
+            override fun onMessage(buffer: RTCDataChannelBuffer) {
+                trySendBlocking(DataChannelEvent.MessageReceived(buffer))
+            }
+        }
+
+        jvm.registerObserver(observer)
+
+        awaitClose { jvm.unregisterObserver() }
+    }
+
+    actual val onOpen: Flow<Unit> = dataChannelEvent
+        .filter { it is DataChannelEvent.StateChanged && jvm.state == RTCDataChannelState.OPEN }
+        .map { }
+
+    actual val onClosing: Flow<Unit> = dataChannelEvent
+        .filter { it is DataChannelEvent.StateChanged && jvm.state == RTCDataChannelState.CLOSING }
+        .map { }
+
+    actual val onClose: Flow<Unit> = dataChannelEvent
+        .filter { it is DataChannelEvent.StateChanged && jvm.state == RTCDataChannelState.CLOSED }
+        .map { }
+
+    private val errorFlow: MutableStateFlow<String> = MutableStateFlow("")
+
+    actual val onError: Flow<String> = errorFlow
+
+    actual val onMessage: Flow<ByteArray> = dataChannelEvent
+        .map { it as? DataChannelEvent.MessageReceived }
+        .filterNotNull()
+        .map { it.buffer.data.toByteArray() }
+
+    actual fun send(data: ByteArray): Boolean {
+        val buffer = RTCDataChannelBuffer(ByteBuffer.wrap(data), true)
+        return try {
+            jvm.send(buffer)
+            true
+        } catch (e: Exception) {
+            errorFlow.tryEmit(e.message.orEmpty())
+            false
+        }
+    }
+
+    actual fun close() = jvm.dispose()
+
+    private fun RTCDataChannelState.asCommon(): DataChannelState {
+        return when (this) {
+            RTCDataChannelState.CONNECTING -> DataChannelState.Connecting
+            RTCDataChannelState.OPEN -> DataChannelState.Open
+            RTCDataChannelState.CLOSING -> DataChannelState.Closing
+            RTCDataChannelState.CLOSED -> DataChannelState.Closed
+        }
+    }
+
+    private sealed interface DataChannelEvent {
+        object StateChanged : DataChannelEvent
+        data class MessageReceived(val buffer: RTCDataChannelBuffer) : DataChannelEvent
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/IceCandidate.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/IceCandidate.kt
@@ -6,13 +6,13 @@ actual class IceCandidate internal constructor(val native: RTCIceCandidate) {
     actual constructor(
         sdpMid: String,
         sdpMLineIndex: Int,
-        candidate: String
+        candidate: String,
     ) : this(
         RTCIceCandidate(
             sdpMid,
             sdpMLineIndex,
-            candidate
-        )
+            candidate,
+        ),
     )
 
     actual val sdpMid: String

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/IceCandidate.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/IceCandidate.kt
@@ -1,0 +1,28 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCIceCandidate
+
+actual class IceCandidate internal constructor(val native: RTCIceCandidate) {
+    actual constructor(
+        sdpMid: String,
+        sdpMLineIndex: Int,
+        candidate: String
+    ) : this(
+        RTCIceCandidate(
+            sdpMid,
+            sdpMLineIndex,
+            candidate
+        )
+    )
+
+    actual val sdpMid: String
+        get() = native.sdpMid
+
+    actual val sdpMLineIndex: Int
+        get() = native.sdpMLineIndex
+
+    actual val candidate: String
+        get() = native.sdp
+
+    actual override fun toString(): String = native.toString()
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/IceServer.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/IceServer.kt
@@ -1,0 +1,34 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCIceServer
+
+actual class IceServer internal constructor(val native: RTCIceServer) {
+    actual constructor(
+        urls: List<String>,
+        username: String,
+        password: String,
+        tlsCertPolicy: TlsCertPolicy,
+        hostname: String,
+        tlsAlpnProtocols: List<String>?,
+        tlsEllipticCurves: List<String>?
+    ) : this(
+        RTCIceServer().apply {
+            this.urls = urls
+            this.username = username
+            this.password = password
+            this.tlsCertPolicy = tlsCertPolicy.asNative()
+            this.hostname = hostname
+            this.tlsAlpnProtocols = tlsAlpnProtocols
+            this.tlsEllipticCurves = tlsEllipticCurves
+        }
+    )
+
+    actual override fun toString(): String = native.toString()
+}
+
+private fun TlsCertPolicy.asNative(): dev.onvoid.webrtc.TlsCertPolicy {
+    return when (this) {
+        TlsCertPolicy.TlsCertPolicySecure -> dev.onvoid.webrtc.TlsCertPolicy.SECURE
+        TlsCertPolicy.TlsCertPolicyInsecureNoCheck -> dev.onvoid.webrtc.TlsCertPolicy.INSECURE_NO_CHECK
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/IceServer.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/IceServer.kt
@@ -10,7 +10,7 @@ actual class IceServer internal constructor(val native: RTCIceServer) {
         tlsCertPolicy: TlsCertPolicy,
         hostname: String,
         tlsAlpnProtocols: List<String>?,
-        tlsEllipticCurves: List<String>?
+        tlsEllipticCurves: List<String>?,
     ) : this(
         RTCIceServer().apply {
             this.urls = urls
@@ -20,7 +20,7 @@ actual class IceServer internal constructor(val native: RTCIceServer) {
             this.hostname = hostname
             this.tlsAlpnProtocols = tlsAlpnProtocols
             this.tlsEllipticCurves = tlsEllipticCurves
-        }
+        },
     )
 
     actual override fun toString(): String = native.toString()

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaDevices.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaDevices.kt
@@ -27,9 +27,13 @@ class MediaDevicesImpl : MediaDevices {
             MediaDeviceInfo(
                 deviceId = it.name,
                 label = it.descriptor,
-                kind = if (nativeAudioDevices.contains(it)) MediaDeviceKind.AudioInput
-                else if (nativeVideoDevices.contains(it)) MediaDeviceKind.VideoInput
-                else error("Unknown device type!")
+                kind = if (nativeAudioDevices.contains(it)) {
+                    MediaDeviceKind.AudioInput
+                } else if (nativeVideoDevices.contains(it)) {
+                    MediaDeviceKind.VideoInput
+                } else {
+                    error("Unknown device type!")
+                },
             )
         }
     }

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaDevices.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaDevices.kt
@@ -1,0 +1,36 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.media.MediaDevices as NativeMediaDevices
+
+internal actual val mediaDevices: MediaDevices
+    get() = MediaDevicesImpl()
+
+class MediaDevicesImpl : MediaDevices {
+
+    override suspend fun getUserMedia(streamConstraints: MediaStreamConstraintsBuilder.() -> Unit): MediaStream {
+        TODO("Not yet implemented for JVM platform")
+    }
+
+    override suspend fun getDisplayMedia(): MediaStream {
+        TODO("Not yet implemented for JVM platform")
+    }
+
+    override suspend fun supportsDisplayMedia(): Boolean = false
+
+    override suspend fun enumerateDevices(): List<MediaDeviceInfo> {
+        val nativeAudioDevices = NativeMediaDevices.getAudioCaptureDevices()
+        val nativeVideoDevices = NativeMediaDevices.getVideoCaptureDevices()
+
+        val allDevices = nativeAudioDevices + nativeVideoDevices
+
+        return allDevices.map {
+            MediaDeviceInfo(
+                deviceId = it.name,
+                label = it.descriptor,
+                kind = if (nativeAudioDevices.contains(it)) MediaDeviceKind.AudioInput
+                else if (nativeVideoDevices.contains(it)) MediaDeviceKind.VideoInput
+                else error("Unknown device type!")
+            )
+        }
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 
 actual class MediaStream internal constructor(
     val native: MediaStream?,
-    actual val id: String = native?.id() ?: UUID.randomUUID().toString()
+    actual val id: String = native?.id() ?: UUID.randomUUID().toString(),
 ) {
     private val _tracks = mutableListOf<MediaStreamTrack>()
     actual val tracks: List<MediaStreamTrack> = _tracks

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaStream.kt
@@ -1,0 +1,45 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.media.MediaStream
+import dev.onvoid.webrtc.media.audio.AudioTrack
+import dev.onvoid.webrtc.media.video.VideoTrack
+import java.util.UUID
+
+actual class MediaStream internal constructor(
+    val native: MediaStream?,
+    actual val id: String = native?.id() ?: UUID.randomUUID().toString()
+) {
+    private val _tracks = mutableListOf<MediaStreamTrack>()
+    actual val tracks: List<MediaStreamTrack> = _tracks
+
+    actual fun addTrack(track: MediaStreamTrack) {
+        native?.let {
+            when (track.native) {
+                is AudioTrack -> it.addTrack(track.native)
+                is VideoTrack -> it.addTrack(track.native)
+                else -> error("Unknown MediaStreamTrack kind: ${track.kind}")
+            }
+        }
+        _tracks += track
+    }
+
+    actual fun getTrackById(id: String): MediaStreamTrack? {
+        return tracks.firstOrNull { it.id == id }
+    }
+
+    actual fun removeTrack(track: MediaStreamTrack) {
+        native?.let {
+            when (track.native) {
+                is AudioTrack -> it.removeTrack(track.native)
+                is VideoTrack -> it.removeTrack(track.native)
+                else -> error("Unknown MediaStreamTrack kind: ${track.kind}")
+            }
+        }
+        _tracks -= track
+    }
+
+    actual fun release() {
+        tracks.forEach(MediaStreamTrack::stop)
+        native?.dispose()
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaStreamTrack.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/MediaStreamTrack.kt
@@ -1,0 +1,71 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.media.MediaStreamTrack
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+actual abstract class MediaStreamTrack internal constructor(val native: MediaStreamTrack) {
+
+    actual val id: String
+        get() = native.id
+
+    actual val kind: MediaStreamTrackKind
+        get() = when (native.kind) {
+            MediaStreamTrack.AUDIO_TRACK_KIND -> MediaStreamTrackKind.Audio
+            MediaStreamTrack.VIDEO_TRACK_KIND -> MediaStreamTrackKind.Video
+            else -> error("Unknown track kind: ${native.kind}")
+        }
+
+    actual val label: String
+        get() = when (kind) {
+            // TODO(shubham): get real capturing device (front/back camera, internal microphone, headset)
+            MediaStreamTrackKind.Audio -> "microphone"
+            MediaStreamTrackKind.Video -> "camera"
+        }
+
+    actual var enabled: Boolean
+        get() = native.isEnabled
+        set(value) {
+            if (value == native.isEnabled) return
+            native.isEnabled = value
+            onSetEnabled(value)
+        }
+
+    private val _state = MutableStateFlow(getInitialState())
+    actual val state: StateFlow<MediaStreamTrackState> = _state.asStateFlow()
+
+    actual fun stop() {
+        if (_state.value is MediaStreamTrackState.Ended) return
+        _state.update { MediaStreamTrackState.Ended(it.muted) }
+        onStop()
+    }
+
+    protected fun setMuted(muted: Boolean) {
+        if (muted) {
+            _state.update { it.mute() }
+        } else {
+            _state.update { it.unmute() }
+        }
+    }
+
+    protected abstract fun onSetEnabled(enabled: Boolean)
+
+    protected abstract fun onStop()
+
+    private fun getInitialState(): MediaStreamTrackState {
+        return when (checkNotNull(native.state)) {
+            dev.onvoid.webrtc.media.MediaStreamTrackState.LIVE -> MediaStreamTrackState.Live(muted = false)
+            dev.onvoid.webrtc.media.MediaStreamTrackState.ENDED -> MediaStreamTrackState.Ended(muted = false)
+        }
+    }
+}
+
+internal fun MediaStreamTrack.asCommon(): com.shepeliev.webrtckmp.MediaStreamTrack {
+    return when (this) {
+        is dev.onvoid.webrtc.media.audio.AudioTrack -> AudioStreamTrack(this)
+        is dev.onvoid.webrtc.media.video.VideoTrack -> VideoStreamTrack(this)
+        else -> error("Unknown native MediaStreamTrack: $this")
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/PeerConnection.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/PeerConnection.kt
@@ -28,7 +28,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
 
     val jvm: RTCPeerConnection = WebRtc.peerConnectionFactory.createPeerConnection(
         rtcConfiguration.jvm,
-        JvmPeerConnectionObserver()
+        JvmPeerConnectionObserver(),
     ) ?: error("Creating PeerConnection failed")
 
     actual val localDescription: SessionDescription?
@@ -64,7 +64,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
         maxRetransmitTimeMs: Int,
         maxRetransmits: Int,
         protocol: String,
-        negotiated: Boolean
+        negotiated: Boolean,
     ): DataChannel? {
         val init = RTCDataChannelInit().also {
             it.id = id
@@ -84,7 +84,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
                     options.iceRestart?.let { iceRestart = it }
                     options.voiceActivityDetection?.let { voiceActivityDetection = it }
                 },
-                createSdpObserver(cont)
+                createSdpObserver(cont),
             )
         }
     }
@@ -95,7 +95,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
                 RTCAnswerOptions().apply {
                     options.voiceActivityDetection?.let { voiceActivityDetection = it }
                 },
-                createSdpObserver(cont)
+                createSdpObserver(cont),
             )
         }
     }
@@ -116,7 +116,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
         return suspendCoroutine {
             jvm.setLocalDescription(
                 description.asNative(),
-                setSdpObserver(it)
+                setSdpObserver(it),
             )
         }
     }
@@ -125,7 +125,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
         return suspendCoroutine {
             jvm.setRemoteDescription(
                 description.asNative(),
-                setSdpObserver(it)
+                setSdpObserver(it),
             )
         }
     }
@@ -226,8 +226,8 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
         override fun onStandardizedIceConnectionChange(newState: RTCIceConnectionState) {
             _peerConnectionEvent.tryEmit(
                 PeerConnectionEvent.StandardizedIceConnectionChange(
-                    newState.asCommon()
-                )
+                    newState.asCommon(),
+                ),
             )
         }
 
@@ -246,11 +246,15 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
         }
 
         override fun onIceCandidatesRemoved(candidates: Array<out RTCIceCandidate>) {
-            _peerConnectionEvent.tryEmit(PeerConnectionEvent.RemovedIceCandidates(candidates.map {
-                IceCandidate(
-                    it
-                )
-            }))
+            _peerConnectionEvent.tryEmit(
+                PeerConnectionEvent.RemovedIceCandidates(
+                    candidates.map {
+                        IceCandidate(
+                            it,
+                        )
+                    },
+                ),
+            )
         }
 
         override fun onAddStream(nativeStream: dev.onvoid.webrtc.media.MediaStream) {
@@ -277,7 +281,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
 
         override fun onAddTrack(
             receiver: RTCRtpReceiver,
-            nativeStreams: Array<out dev.onvoid.webrtc.media.MediaStream>
+            nativeStreams: Array<out dev.onvoid.webrtc.media.MediaStream>,
         ) {
             val transceiver = jvm.transceivers.find { it.receiver == receiver } ?: return
 
@@ -306,7 +310,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
                 receiver = RtpReceiver(receiver, receiverTrack),
                 streams = streams,
                 track = receiverTrack,
-                transceiver = RtpTransceiver(transceiver, senderTrack)
+                transceiver = RtpTransceiver(transceiver, senderTrack),
             )
 
             _peerConnectionEvent.tryEmit(PeerConnectionEvent.Track(trackEvent))
@@ -315,7 +319,7 @@ actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguratio
         override fun onRemoveTrack(receiver: RTCRtpReceiver) {
             val track = remoteTracks.remove(receiver.track?.id)
             _peerConnectionEvent.tryEmit(
-                PeerConnectionEvent.RemoveTrack(RtpReceiver(receiver, track))
+                PeerConnectionEvent.RemoveTrack(RtpReceiver(receiver, track)),
             )
             track?.stop()
         }

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/PeerConnection.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/PeerConnection.kt
@@ -1,0 +1,373 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.CreateSessionDescriptionObserver
+import dev.onvoid.webrtc.PeerConnectionObserver
+import dev.onvoid.webrtc.RTCAnswerOptions
+import dev.onvoid.webrtc.RTCBundlePolicy
+import dev.onvoid.webrtc.RTCDataChannel
+import dev.onvoid.webrtc.RTCDataChannelInit
+import dev.onvoid.webrtc.RTCIceCandidate
+import dev.onvoid.webrtc.RTCIceConnectionState
+import dev.onvoid.webrtc.RTCIceGatheringState
+import dev.onvoid.webrtc.RTCOfferOptions
+import dev.onvoid.webrtc.RTCPeerConnection
+import dev.onvoid.webrtc.RTCPeerConnectionState
+import dev.onvoid.webrtc.RTCRtpReceiver
+import dev.onvoid.webrtc.RTCSessionDescription
+import dev.onvoid.webrtc.RTCSignalingState
+import dev.onvoid.webrtc.SetSessionDescriptionObserver
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+actual class PeerConnection actual constructor(rtcConfiguration: RtcConfiguration) {
+
+    val jvm: RTCPeerConnection = WebRtc.peerConnectionFactory.createPeerConnection(
+        rtcConfiguration.jvm,
+        JvmPeerConnectionObserver()
+    ) ?: error("Creating PeerConnection failed")
+
+    actual val localDescription: SessionDescription?
+        get() = jvm.localDescription?.asCommon()
+
+    actual val remoteDescription: SessionDescription?
+        get() = jvm.remoteDescription?.asCommon()
+
+    actual val signalingState: SignalingState
+        get() = jvm.signalingState.asCommon()
+
+    actual val iceConnectionState: IceConnectionState
+        get() = jvm.iceConnectionState.asCommon()
+
+    actual val connectionState: PeerConnectionState
+        get() = jvm.connectionState.asCommon()
+
+    actual val iceGatheringState: IceGatheringState
+        get() = jvm.iceGatheringState.asCommon()
+
+    private val _peerConnectionEvent =
+        MutableSharedFlow<PeerConnectionEvent>(extraBufferCapacity = FLOW_BUFFER_CAPACITY)
+    internal actual val peerConnectionEvent: Flow<PeerConnectionEvent> =
+        _peerConnectionEvent.asSharedFlow()
+
+    private val localTracks = mutableMapOf<String, MediaStreamTrack>()
+    private val remoteTracks = mutableMapOf<String, MediaStreamTrack>()
+
+    actual fun createDataChannel(
+        label: String,
+        id: Int,
+        ordered: Boolean,
+        maxRetransmitTimeMs: Int,
+        maxRetransmits: Int,
+        protocol: String,
+        negotiated: Boolean
+    ): DataChannel? {
+        val init = RTCDataChannelInit().also {
+            it.id = id
+            it.ordered = ordered
+            it.maxPacketLifeTime = maxRetransmitTimeMs
+            it.maxRetransmits = maxRetransmits
+            it.protocol = protocol
+            it.negotiated = negotiated
+        }
+        return jvm.createDataChannel(label, init)?.let { DataChannel(it) }
+    }
+
+    actual suspend fun createOffer(options: OfferAnswerOptions): SessionDescription {
+        return suspendCoroutine { cont ->
+            jvm.createOffer(
+                RTCOfferOptions().apply {
+                    options.iceRestart?.let { iceRestart = it }
+                    options.voiceActivityDetection?.let { voiceActivityDetection = it }
+                },
+                createSdpObserver(cont)
+            )
+        }
+    }
+
+    actual suspend fun createAnswer(options: OfferAnswerOptions): SessionDescription {
+        return suspendCoroutine { cont ->
+            jvm.createAnswer(
+                RTCAnswerOptions().apply {
+                    options.voiceActivityDetection?.let { voiceActivityDetection = it }
+                },
+                createSdpObserver(cont)
+            )
+        }
+    }
+
+    private fun createSdpObserver(continuation: Continuation<SessionDescription>): CreateSessionDescriptionObserver {
+        return object : CreateSessionDescriptionObserver {
+            override fun onSuccess(description: RTCSessionDescription?) {
+                description?.asCommon()?.let { continuation.resume(it) }
+            }
+
+            override fun onFailure(error: String?) {
+                continuation.resumeWithException(RuntimeException("Creating SDP failed: $error"))
+            }
+        }
+    }
+
+    actual suspend fun setLocalDescription(description: SessionDescription) {
+        return suspendCoroutine {
+            jvm.setLocalDescription(
+                description.asNative(),
+                setSdpObserver(it)
+            )
+        }
+    }
+
+    actual suspend fun setRemoteDescription(description: SessionDescription) {
+        return suspendCoroutine {
+            jvm.setRemoteDescription(
+                description.asNative(),
+                setSdpObserver(it)
+            )
+        }
+    }
+
+    private fun setSdpObserver(continuation: Continuation<Unit>): SetSessionDescriptionObserver {
+        return object : SetSessionDescriptionObserver {
+            override fun onSuccess() {
+                continuation.resume(Unit)
+            }
+
+            override fun onFailure(error: String?) {
+                continuation.resumeWithException(RuntimeException("Setting SDP failed: $error"))
+            }
+        }
+    }
+
+    actual fun setConfiguration(configuration: RtcConfiguration): Boolean {
+        return try {
+            jvm.configuration = configuration.jvm
+            true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+
+    actual fun addIceCandidate(candidate: IceCandidate): Boolean {
+        return try {
+            jvm.addIceCandidate(candidate.native)
+            true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+
+    actual fun removeIceCandidates(candidates: List<IceCandidate>): Boolean {
+        return try {
+            jvm.removeIceCandidates(candidates.map { it.native }.toTypedArray())
+            true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+
+    actual fun getSenders(): List<RtpSender> = jvm.senders.map {
+        RtpSender(it, localTracks[it.track?.id])
+    }
+
+    actual fun getReceivers(): List<RtpReceiver> = jvm.receivers.map {
+        RtpReceiver(it, remoteTracks[it.track?.id])
+    }
+
+    actual fun getTransceivers(): List<RtpTransceiver> = jvm.transceivers.map {
+        val senderTrack = localTracks[it.sender.track?.id]
+        RtpTransceiver(it, senderTrack)
+    }
+
+    actual fun addTrack(track: MediaStreamTrack, vararg streams: MediaStream): RtpSender {
+        val streamIds = streams.map { it.id }
+        localTracks[track.id] = track
+        return RtpSender(jvm.addTrack(track.native, streamIds), track)
+    }
+
+    actual fun removeTrack(sender: RtpSender): Boolean {
+        return try {
+            localTracks.remove(sender.track?.id)
+            jvm.removeTrack(sender.native)
+            true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+
+    actual suspend fun getStats(): RtcStatsReport? {
+        return suspendCoroutine { cont ->
+            jvm.getStats { cont.resume(RtcStatsReport(it)) }
+        }
+    }
+
+    actual fun close() {
+        remoteTracks.values.forEach(MediaStreamTrack::stop)
+        remoteTracks.clear()
+        jvm.close()
+    }
+
+    internal inner class JvmPeerConnectionObserver : PeerConnectionObserver {
+        override fun onSignalingChange(newState: RTCSignalingState) {
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.SignalingStateChange(newState.asCommon()))
+        }
+
+        override fun onIceConnectionChange(newState: RTCIceConnectionState) {
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.IceConnectionStateChange(newState.asCommon()))
+        }
+
+        override fun onStandardizedIceConnectionChange(newState: RTCIceConnectionState) {
+            _peerConnectionEvent.tryEmit(
+                PeerConnectionEvent.StandardizedIceConnectionChange(
+                    newState.asCommon()
+                )
+            )
+        }
+
+        override fun onConnectionChange(newState: RTCPeerConnectionState) {
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.ConnectionStateChange(newState.asCommon()))
+        }
+
+        override fun onIceConnectionReceivingChange(receiving: Boolean) {}
+
+        override fun onIceGatheringChange(newState: RTCIceGatheringState) {
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.IceGatheringStateChange(newState.asCommon()))
+        }
+
+        override fun onIceCandidate(candidate: RTCIceCandidate) {
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.NewIceCandidate(IceCandidate(candidate)))
+        }
+
+        override fun onIceCandidatesRemoved(candidates: Array<out RTCIceCandidate>) {
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.RemovedIceCandidates(candidates.map {
+                IceCandidate(
+                    it
+                )
+            }))
+        }
+
+        override fun onAddStream(nativeStream: dev.onvoid.webrtc.media.MediaStream) {
+            // this deprecated API should not longer be used
+            // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/onaddstream
+        }
+
+        override fun onRemoveStream(nativeStream: dev.onvoid.webrtc.media.MediaStream) {
+            // The removestream event has been removed from the WebRTC specification in favor of
+            // the existing removetrack event on the remote MediaStream and the corresponding
+            // MediaStream.onremovetrack event handler property of the remote MediaStream.
+            // The RTCPeerConnection API is now track-based, so having zero tracks in the remote
+            // stream is equivalent to the remote stream being removed and the old removestream event.
+            // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/onremovestream
+        }
+
+        override fun onDataChannel(dataChannel: RTCDataChannel) {
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.NewDataChannel(DataChannel(dataChannel)))
+        }
+
+        override fun onRenegotiationNeeded() {
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.NegotiationNeeded)
+        }
+
+        override fun onAddTrack(
+            receiver: RTCRtpReceiver,
+            nativeStreams: Array<out dev.onvoid.webrtc.media.MediaStream>
+        ) {
+            val transceiver = jvm.transceivers.find { it.receiver == receiver } ?: return
+
+            val audioTracks = nativeStreams
+                .flatMap { it.audioTracks.toList() }
+                .map { remoteTracks.getOrPut(it.id) { AudioStreamTrack(it) } }
+
+            val videoTracks = nativeStreams
+                .flatMap { it.videoTracks.toList() }
+                .map { remoteTracks.getOrPut(it.id) { VideoStreamTrack(it) } }
+
+            val streams = nativeStreams.map { nativeStream ->
+                MediaStream(
+                    native = nativeStream,
+                    id = nativeStream.id(),
+                ).also { stream ->
+                    audioTracks.forEach(stream::addTrack)
+                    videoTracks.forEach(stream::addTrack)
+                }
+            }
+
+            val senderTrack = localTracks[transceiver.sender.track?.id]
+            val receiverTrack = remoteTracks[receiver.track?.id]
+
+            val trackEvent = TrackEvent(
+                receiver = RtpReceiver(receiver, receiverTrack),
+                streams = streams,
+                track = receiverTrack,
+                transceiver = RtpTransceiver(transceiver, senderTrack)
+            )
+
+            _peerConnectionEvent.tryEmit(PeerConnectionEvent.Track(trackEvent))
+        }
+
+        override fun onRemoveTrack(receiver: RTCRtpReceiver) {
+            val track = remoteTracks.remove(receiver.track?.id)
+            _peerConnectionEvent.tryEmit(
+                PeerConnectionEvent.RemoveTrack(RtpReceiver(receiver, track))
+            )
+            track?.stop()
+        }
+    }
+}
+
+private fun RTCSignalingState.asCommon(): SignalingState {
+    return when (this) {
+        RTCSignalingState.STABLE -> SignalingState.Stable
+        RTCSignalingState.HAVE_LOCAL_OFFER -> SignalingState.HaveLocalOffer
+        RTCSignalingState.HAVE_LOCAL_PR_ANSWER -> SignalingState.HaveLocalPranswer
+        RTCSignalingState.HAVE_REMOTE_OFFER -> SignalingState.HaveRemoteOffer
+        RTCSignalingState.HAVE_REMOTE_PR_ANSWER -> SignalingState.HaveRemotePranswer
+        RTCSignalingState.CLOSED -> SignalingState.Closed
+    }
+}
+
+private fun RTCIceConnectionState.asCommon(): IceConnectionState {
+    return when (this) {
+        RTCIceConnectionState.NEW -> IceConnectionState.New
+        RTCIceConnectionState.CHECKING -> IceConnectionState.Checking
+        RTCIceConnectionState.CONNECTED -> IceConnectionState.Connected
+        RTCIceConnectionState.COMPLETED -> IceConnectionState.Completed
+        RTCIceConnectionState.FAILED -> IceConnectionState.Failed
+        RTCIceConnectionState.DISCONNECTED -> IceConnectionState.Disconnected
+        RTCIceConnectionState.CLOSED -> IceConnectionState.Closed
+    }
+}
+
+private fun RTCPeerConnectionState.asCommon(): PeerConnectionState {
+    return when (this) {
+        RTCPeerConnectionState.NEW -> PeerConnectionState.New
+        RTCPeerConnectionState.CONNECTING -> PeerConnectionState.Connecting
+        RTCPeerConnectionState.CONNECTED -> PeerConnectionState.Connected
+        RTCPeerConnectionState.DISCONNECTED -> PeerConnectionState.Disconnected
+        RTCPeerConnectionState.FAILED -> PeerConnectionState.Failed
+        RTCPeerConnectionState.CLOSED -> PeerConnectionState.Closed
+    }
+}
+
+private fun RTCIceGatheringState.asCommon(): IceGatheringState {
+    return when (this) {
+        RTCIceGatheringState.NEW -> IceGatheringState.New
+        RTCIceGatheringState.GATHERING -> IceGatheringState.Gathering
+        RTCIceGatheringState.COMPLETE -> IceGatheringState.Complete
+    }
+}
+
+private fun BundlePolicy.asNative(): RTCBundlePolicy {
+    return when (this) {
+        BundlePolicy.MaxBundle -> RTCBundlePolicy.MAX_BUNDLE
+        BundlePolicy.Balanced -> RTCBundlePolicy.BALANCED
+        BundlePolicy.MaxCompat -> RTCBundlePolicy.MAX_COMPAT
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcCertificatePem.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcCertificatePem.kt
@@ -15,7 +15,7 @@ actual class RtcCertificatePem(val native: RTCCertificatePEM) {
     actual companion object {
         actual suspend fun generateCertificate(
             keyType: KeyType,
-            expires: Long
+            expires: Long,
         ): RtcCertificatePem {
             TODO("Not yet implemented!")
         }

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcCertificatePem.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcCertificatePem.kt
@@ -1,0 +1,23 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCCertificatePEM
+
+actual class RtcCertificatePem(val native: RTCCertificatePEM) {
+    actual val privateKey: String
+        get() = native.privateKey
+
+    actual val certificate: String
+        get() = native.certificate
+
+    val expires: Long
+        get() = native.expires
+
+    actual companion object {
+        actual suspend fun generateCertificate(
+            keyType: KeyType,
+            expires: Long
+        ): RtcCertificatePem {
+            TODO("Not yet implemented!")
+        }
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcConfiguration.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcConfiguration.kt
@@ -1,0 +1,47 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCBundlePolicy
+import dev.onvoid.webrtc.RTCConfiguration
+import dev.onvoid.webrtc.RTCIceTransportPolicy
+import dev.onvoid.webrtc.RTCRtcpMuxPolicy
+
+actual class RtcConfiguration actual constructor(
+    bundlePolicy: BundlePolicy,
+    certificates: List<RtcCertificatePem>?,
+    iceCandidatePoolSize: Int,
+    iceServers: List<IceServer>,
+    iceTransportPolicy: IceTransportPolicy,
+    rtcpMuxPolicy: RtcpMuxPolicy,
+) {
+    val jvm = RTCConfiguration().apply {
+        this.bundlePolicy = bundlePolicy.asNative()
+        this.iceServers = iceServers.map { it.native }
+        this.certificates = certificates?.map { it.native }
+        this.iceTransportPolicy = iceTransportPolicy.asNative()
+        this.rtcpMuxPolicy = rtcpMuxPolicy.asNative()
+    }
+}
+
+private fun RtcpMuxPolicy.asNative(): RTCRtcpMuxPolicy {
+    return when (this) {
+        RtcpMuxPolicy.Negotiate -> RTCRtcpMuxPolicy.NEGOTIATE
+        RtcpMuxPolicy.Require -> RTCRtcpMuxPolicy.REQUIRE
+    }
+}
+
+private fun BundlePolicy.asNative(): RTCBundlePolicy {
+    return when (this) {
+        BundlePolicy.Balanced -> RTCBundlePolicy.BALANCED
+        BundlePolicy.MaxBundle -> RTCBundlePolicy.MAX_BUNDLE
+        BundlePolicy.MaxCompat -> RTCBundlePolicy.MAX_COMPAT
+    }
+}
+
+private fun IceTransportPolicy.asNative(): RTCIceTransportPolicy {
+    return when (this) {
+        IceTransportPolicy.None -> RTCIceTransportPolicy.NONE
+        IceTransportPolicy.Relay -> RTCIceTransportPolicy.RELAY
+        IceTransportPolicy.NoHost -> RTCIceTransportPolicy.NO_HOST
+        IceTransportPolicy.All -> RTCIceTransportPolicy.ALL
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcStats.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcStats.kt
@@ -1,0 +1,21 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCStats
+
+actual class RtcStats(val native: RTCStats) {
+    actual val timestampUs: Long
+        get() = native.timestamp
+
+    actual val type: String
+        get() = native.type.name
+
+    actual val id: String
+        get() = native.id
+
+    actual val members: Map<String, Any>
+        get() = native.members
+
+    actual override fun toString(): String {
+        return "RtcStats(timestampUs=$timestampUs, type=$type, id=$id, members=$members)"
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcStatsReport.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtcStatsReport.kt
@@ -1,0 +1,14 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCStatsReport
+
+actual class RtcStatsReport(val native: RTCStatsReport) {
+    actual val timestampUs: Long
+        get() = 0 // TODO
+    actual val stats: Map<String, RtcStats>
+        get() = native.stats.mapValues { RtcStats(it.value) }
+
+    actual override fun toString(): String {
+        return "RtcStatsReport(timestampUs=$timestampUs, stats=[${stats.toList().joinToString()}])"
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpParameters.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpParameters.kt
@@ -1,0 +1,100 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCRtcpParameters
+import dev.onvoid.webrtc.RTCRtpCodecParameters
+import dev.onvoid.webrtc.RTCRtpEncodingParameters
+import dev.onvoid.webrtc.RTCRtpHeaderExtensionParameters
+import dev.onvoid.webrtc.RTCRtpParameters
+
+actual class RtpParameters(
+    val native: RTCRtpParameters
+) {
+    actual val codecs: List<RtpCodecParameters>
+        get() = native.codecs.map { RtpCodecParameters(it) }
+
+    actual val encodings: List<RtpEncodingParameters>
+        get() = emptyList() // TODO
+
+    actual val headerExtension: List<HeaderExtension>
+        get() = native.headerExtensions.map { HeaderExtension(it) }
+
+    actual val rtcp: RtcpParameters
+        get() = RtcpParameters(native.rtcp)
+
+    actual val transactionId: String
+        get() = "" // TODO
+}
+
+actual class RtpCodecParameters(val native: RTCRtpCodecParameters) {
+    actual val payloadType: Int
+        get() = native.payloadType
+
+
+    actual val mimeType: String?
+        get() = "${native.codecName.lowercase()}/${native.mediaType.name.lowercase()}"
+
+    actual val clockRate: Int?
+        get() = native.clockRate
+
+    actual val numChannels: Int?
+        get() = native.channels
+
+    actual val parameters: Map<String, String>
+        get() = native.parameters
+
+}
+
+actual class RtpEncodingParameters(val native: RTCRtpEncodingParameters) {
+    actual val rid: String?
+        get() = null
+
+    actual val active: Boolean
+        get() = native.active
+
+    actual val bitratePriority: Double
+        // Referred from [org.webrtc.RtpParameters.Encoding] class
+        get() = 1.0
+
+    actual val networkPriority: Int
+        // Referred from [org.webrtc.RtpParameters.Encoding] class
+        get() = 1
+
+    actual val maxBitrateBps: Int?
+        get() = native.maxBitrate
+
+    actual val minBitrateBps: Int?
+        get() = native.minBitrate
+
+    actual val maxFramerate: Int?
+        get() = native.maxFramerate.toInt()
+
+    actual val numTemporalLayers: Int?
+        get() = null
+
+    actual val scaleResolutionDownBy: Double?
+        get() = native.scaleResolutionDownBy
+
+    actual val ssrc: Long?
+        get() = native.ssrc
+
+}
+
+actual class HeaderExtension(val native: RTCRtpHeaderExtensionParameters) {
+    actual val uri: String
+        get() = native.uri
+
+    actual val id: Int
+        get() = native.id
+
+    actual val encrypted: Boolean
+        get() = native.encrypted
+
+}
+
+actual class RtcpParameters(val native: RTCRtcpParameters) {
+    actual val cname: String
+        get() = native.cName
+
+    actual val reducedSize: Boolean
+        get() = native.reducedSize
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpParameters.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpParameters.kt
@@ -7,7 +7,7 @@ import dev.onvoid.webrtc.RTCRtpHeaderExtensionParameters
 import dev.onvoid.webrtc.RTCRtpParameters
 
 actual class RtpParameters(
-    val native: RTCRtpParameters
+    val native: RTCRtpParameters,
 ) {
     actual val codecs: List<RtpCodecParameters>
         get() = native.codecs.map { RtpCodecParameters(it) }
@@ -29,7 +29,6 @@ actual class RtpCodecParameters(val native: RTCRtpCodecParameters) {
     actual val payloadType: Int
         get() = native.payloadType
 
-
     actual val mimeType: String?
         get() = "${native.codecName.lowercase()}/${native.mediaType.name.lowercase()}"
 
@@ -41,7 +40,6 @@ actual class RtpCodecParameters(val native: RTCRtpCodecParameters) {
 
     actual val parameters: Map<String, String>
         get() = native.parameters
-
 }
 
 actual class RtpEncodingParameters(val native: RTCRtpEncodingParameters) {
@@ -76,7 +74,6 @@ actual class RtpEncodingParameters(val native: RTCRtpEncodingParameters) {
 
     actual val ssrc: Long?
         get() = native.ssrc
-
 }
 
 actual class HeaderExtension(val native: RTCRtpHeaderExtensionParameters) {
@@ -88,7 +85,6 @@ actual class HeaderExtension(val native: RTCRtpHeaderExtensionParameters) {
 
     actual val encrypted: Boolean
         get() = native.encrypted
-
 }
 
 actual class RtcpParameters(val native: RTCRtcpParameters) {

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpReceiver.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpReceiver.kt
@@ -4,7 +4,7 @@ import dev.onvoid.webrtc.RTCRtpReceiver
 
 actual class RtpReceiver(
     val native: RTCRtpReceiver,
-    actual val track: MediaStreamTrack?
+    actual val track: MediaStreamTrack?,
 ) {
     actual val id: String
         get() = TODO()

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpReceiver.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpReceiver.kt
@@ -1,0 +1,14 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCRtpReceiver
+
+actual class RtpReceiver(
+    val native: RTCRtpReceiver,
+    actual val track: MediaStreamTrack?
+) {
+    actual val id: String
+        get() = TODO()
+
+    actual val parameters: RtpParameters
+        get() = RtpParameters(native = native.parameters)
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpSender.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpSender.kt
@@ -1,0 +1,62 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCRtcpParameters
+import dev.onvoid.webrtc.RTCRtpCodecParameters
+import dev.onvoid.webrtc.RTCRtpEncodingParameters
+import dev.onvoid.webrtc.RTCRtpHeaderExtensionParameters
+import dev.onvoid.webrtc.RTCRtpSendParameters
+import dev.onvoid.webrtc.RTCRtpSender
+import dev.onvoid.webrtc.media.MediaType
+
+actual class RtpSender internal constructor(val native: RTCRtpSender, track: MediaStreamTrack?) {
+    actual val id: String
+        get() = TODO()
+
+    private var _track: MediaStreamTrack? = track
+    actual val track: MediaStreamTrack? get() = _track
+
+    actual var parameters: RtpParameters
+        get() = RtpParameters(native = native.parameters)
+        set(value) {
+            native.parameters = RTCRtpSendParameters().apply {
+                codecs = value.codecs.map {
+                    RTCRtpCodecParameters(
+                        it.payloadType,
+                        MediaType.valueOf(
+                            it.mimeType?.substringBefore("/")?.uppercase()
+                                ?: throw Exception("Unknown Media Type!")
+                        ),
+                        it.mimeType?.substringAfterLast("/")?.lowercase(),
+                        it.clockRate,
+                        it.numChannels,
+                        it.parameters
+                    )
+                }
+                encodings = value.encodings.map { params ->
+                    RTCRtpEncodingParameters().apply {
+                        active = params.active
+                        params.ssrc?.let { ssrc = it }
+                        params.maxFramerate?.let { maxFramerate = it.toDouble() }
+                        params.scaleResolutionDownBy?.let { scaleResolutionDownBy = it }
+                        params.maxBitrateBps?.let { maxBitrate = it }
+                        params.minBitrateBps?.let { minBitrate = it }
+                    }
+                }
+                transactionId = value.transactionId
+                rtcp = RTCRtcpParameters(value.rtcp.cname, value.rtcp.reducedSize)
+                headerExtensions = value.headerExtension.map {
+                    RTCRtpHeaderExtensionParameters(it.uri, it.id, it.encrypted)
+                }
+            }
+        }
+
+    actual val dtmf: DtmfSender?
+        get() = null
+
+    actual suspend fun replaceTrack(track: MediaStreamTrack?) {
+        track?.native?.let { nnNative ->
+            native.replaceTrack(nnNative)
+            _track = track
+        }
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpSender.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpSender.kt
@@ -24,12 +24,12 @@ actual class RtpSender internal constructor(val native: RTCRtpSender, track: Med
                         it.payloadType,
                         MediaType.valueOf(
                             it.mimeType?.substringBefore("/")?.uppercase()
-                                ?: throw Exception("Unknown Media Type!")
+                                ?: throw Exception("Unknown Media Type!"),
                         ),
                         it.mimeType?.substringAfterLast("/")?.lowercase(),
                         it.clockRate,
                         it.numChannels,
-                        it.parameters
+                        it.parameters,
                     )
                 }
                 encodings = value.encodings.map { params ->

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpTransceiver.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpTransceiver.kt
@@ -1,0 +1,52 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCRtpTransceiver
+import dev.onvoid.webrtc.RTCRtpTransceiverDirection
+
+actual class RtpTransceiver(
+    val native: RTCRtpTransceiver,
+    private val senderTrack: MediaStreamTrack?
+) {
+    actual val currentDirection: RtpTransceiverDirection?
+        get() = native.currentDirection.asCommon()
+
+    actual var direction: RtpTransceiverDirection
+        get() = native.direction.asCommon()
+        set(value) {
+            native.direction = value.asNative()
+        }
+
+    actual val mid: String
+        get() = native.mid
+
+    actual val receiver: RtpReceiver
+        get() = RtpReceiver(native.receiver, senderTrack)
+
+    actual val sender: RtpSender
+        get() = RtpSender(native = native.sender, track = senderTrack)
+
+    actual val stopped: Boolean
+        get() = native.stopped()
+
+    actual fun stop() = native.stop()
+}
+
+private fun RTCRtpTransceiverDirection.asCommon(): RtpTransceiverDirection {
+    return when (this) {
+        RTCRtpTransceiverDirection.SEND_ONLY -> RtpTransceiverDirection.SendOnly
+        RTCRtpTransceiverDirection.RECV_ONLY -> RtpTransceiverDirection.RecvOnly
+        RTCRtpTransceiverDirection.INACTIVE -> RtpTransceiverDirection.Inactive
+        RTCRtpTransceiverDirection.SEND_RECV -> RtpTransceiverDirection.SendRecv
+        RTCRtpTransceiverDirection.STOPPED -> RtpTransceiverDirection.Stopped
+    }
+}
+
+private fun RtpTransceiverDirection.asNative(): RTCRtpTransceiverDirection {
+    return when (this) {
+        RtpTransceiverDirection.SendOnly -> RTCRtpTransceiverDirection.SEND_ONLY
+        RtpTransceiverDirection.RecvOnly -> RTCRtpTransceiverDirection.RECV_ONLY
+        RtpTransceiverDirection.Inactive -> RTCRtpTransceiverDirection.INACTIVE
+        RtpTransceiverDirection.SendRecv -> RTCRtpTransceiverDirection.SEND_RECV
+        RtpTransceiverDirection.Stopped -> RTCRtpTransceiverDirection.STOPPED
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpTransceiver.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/RtpTransceiver.kt
@@ -5,7 +5,7 @@ import dev.onvoid.webrtc.RTCRtpTransceiverDirection
 
 actual class RtpTransceiver(
     val native: RTCRtpTransceiver,
-    private val senderTrack: MediaStreamTrack?
+    private val senderTrack: MediaStreamTrack?,
 ) {
     actual val currentDirection: RtpTransceiverDirection?
         get() = native.currentDirection.asCommon()

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/SessionDescriptionExt.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/SessionDescriptionExt.kt
@@ -1,0 +1,30 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.RTCSdpType
+import dev.onvoid.webrtc.RTCSessionDescription
+
+internal fun SessionDescription.asNative(): RTCSessionDescription {
+    return RTCSessionDescription(type.asNative(), sdp)
+}
+
+private fun SessionDescriptionType.asNative(): RTCSdpType {
+    return when (this) {
+        SessionDescriptionType.Offer -> RTCSdpType.OFFER
+        SessionDescriptionType.Pranswer -> RTCSdpType.PR_ANSWER
+        SessionDescriptionType.Answer -> RTCSdpType.ANSWER
+        SessionDescriptionType.Rollback -> RTCSdpType.ROLLBACK
+    }
+}
+
+internal fun RTCSessionDescription.asCommon(): SessionDescription {
+    return SessionDescription(sdpType.asCommon(), sdp)
+}
+
+private fun RTCSdpType.asCommon(): SessionDescriptionType {
+    return when (this) {
+        RTCSdpType.OFFER -> SessionDescriptionType.Offer
+        RTCSdpType.PR_ANSWER -> SessionDescriptionType.Pranswer
+        RTCSdpType.ANSWER -> SessionDescriptionType.Answer
+        RTCSdpType.ROLLBACK -> SessionDescriptionType.Rollback
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/VideoCaptureController.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/VideoCaptureController.kt
@@ -1,0 +1,39 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.media.video.VideoCapture
+import dev.onvoid.webrtc.media.video.VideoCaptureCapability
+
+internal abstract class VideoCaptureController {
+    protected val videoCapturer: VideoCapture by lazy { createVideoCapture() }
+
+    private var disposed = false
+
+    abstract fun createVideoCapture(): VideoCapture
+
+    abstract fun selectVideoSize(): Size
+
+    abstract fun selectFps(): Int
+
+    fun startCapture() {
+        check(!disposed) { "Video capturer disposed" }
+
+        val size = selectVideoSize()
+        val fps = selectFps()
+
+        with(videoCapturer) {
+            setVideoCaptureCapability(VideoCaptureCapability(size.width, size.height, fps))
+            start()
+        }
+    }
+
+    fun stopCapture() {
+        check(!disposed) { "Video capturer disposed" }
+        videoCapturer.stop()
+    }
+
+    fun dispose() {
+        stopCapture()
+        videoCapturer.dispose()
+        disposed = true
+    }
+}

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/VideoStreamTrack.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/VideoStreamTrack.kt
@@ -1,0 +1,120 @@
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.media.video.VideoFrame
+import dev.onvoid.webrtc.media.video.VideoTrack
+import dev.onvoid.webrtc.media.video.VideoTrackSink
+import java.util.Timer
+import java.util.TimerTask
+import java.util.concurrent.atomic.AtomicInteger
+
+actual class VideoStreamTrack internal constructor(
+    private val videoTrack: VideoTrack,
+    private val videoCaptureController: VideoCaptureController? = null,
+) : MediaStreamTrack(videoTrack) {
+
+    // Setup track mute detector for remote tracks only.
+    private val trackMuteDetector: TrackMuteDetector? =
+        if (videoCaptureController == null) TrackMuteDetector() else null
+
+    init {
+        videoCaptureController?.startCapture()
+        trackMuteDetector?.let {
+            addSink(it)
+            it.start()
+        }
+    }
+
+    actual suspend fun switchCamera(deviceId: String?) {
+        (videoCaptureController as? CameraVideoCaptureController)?.let { controller ->
+            deviceId?.let { controller.switchCamera(it) } ?: controller.switchCamera()
+        }
+    }
+
+    fun addSink(sink: VideoTrackSink) {
+        videoTrack.addSink(sink)
+    }
+
+    fun removeSink(sink: VideoTrackSink) {
+        videoTrack.removeSink(sink)
+    }
+
+    override fun onSetEnabled(enabled: Boolean) {
+        if (enabled) {
+            videoCaptureController?.startCapture()
+            trackMuteDetector?.start()
+        } else {
+            videoCaptureController?.stopCapture()
+            trackMuteDetector?.stop()
+        }
+    }
+
+    override fun onStop() {
+        videoCaptureController?.stopCapture()
+        videoCaptureController?.dispose()
+        trackMuteDetector?.let {
+            removeSink(it)
+            it.dispose()
+        }
+    }
+
+    /**
+     * Implements 'mute'/'unmute' events for remote video tracks through the [VideoSink] interface.
+     *
+     * The original idea is from React Native WebRTC
+     * https://github.com/react-native-webrtc/react-native-webrtc/blob/95cf638dfa/jvm/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java#L69
+     */
+    private inner class TrackMuteDetector : VideoTrackSink {
+        private val timer: Timer = Timer("VideoTrackMutedTimer")
+        private var setMuteTask: TimerTask? = null
+
+        @Volatile
+        private var disposed = false
+        private val frameCounter: AtomicInteger = AtomicInteger()
+        private var mutedState = false
+
+        override fun onVideoFrame(frame: VideoFrame) {
+            frameCounter.addAndGet(1)
+        }
+
+        fun start() {
+            if (disposed) return
+
+            synchronized(this) {
+                setMuteTask?.cancel()
+                setMuteTask = object : TimerTask() {
+                    private var lastFrameNumber: Int = frameCounter.get()
+
+                    override fun run() {
+                        if (disposed) return
+
+                        val frameCount = frameCounter.get()
+                        val isMuted = lastFrameNumber == frameCount
+                        if (isMuted != mutedState) {
+                            mutedState = isMuted
+                            setMuted(isMuted)
+                        }
+                        lastFrameNumber = frameCounter.get()
+                    }
+                }
+                timer.schedule(setMuteTask, INITIAL_MUTE_DELAY, MUTE_DELAY)
+            }
+        }
+
+        fun stop() {
+            if (disposed) return
+
+            synchronized(this) {
+                setMuteTask?.cancel()
+                setMuteTask = null
+            }
+        }
+
+        fun dispose() {
+            stop()
+            disposed = true
+        }
+    }
+}
+
+private const val INITIAL_MUTE_DELAY: Long = 3000
+private const val MUTE_DELAY: Long = 1500

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
@@ -41,10 +41,10 @@ class WebRtcBuilder(
 
 @Deprecated(
     "Use WebRtc.initialize()",
-    replaceWith = ReplaceWith("WebRtc.initialize()")
+    replaceWith = ReplaceWith("WebRtc.initialize()"),
 )
 fun initializeWebRtc(
-    build: WebRtcBuilder.() -> Unit = {}
+    build: WebRtcBuilder.() -> Unit = {},
 ) {
     WebRtc.configureBuilder(build)
     WebRtc.initialize()

--- a/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
+++ b/webrtc-kmp/src/jvmMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
@@ -1,0 +1,51 @@
+@file:JvmName("WebRtcKmpJvm")
+
+package com.shepeliev.webrtckmp
+
+import dev.onvoid.webrtc.PeerConnectionFactory
+import dev.onvoid.webrtc.logging.Logging
+
+actual object WebRtc {
+    private var _peerConnectionFactory: PeerConnectionFactory? = null
+    internal val peerConnectionFactory: PeerConnectionFactory
+        get() {
+            if (_peerConnectionFactory == null) initialize()
+            return checkNotNull(_peerConnectionFactory)
+        }
+
+    private var builder = WebRtcBuilder()
+
+    fun configureBuilder(block: WebRtcBuilder.() -> Unit = {}) {
+        block(builder)
+    }
+
+    actual fun initialize() {
+        check(_peerConnectionFactory == null) { "WebRtc already initialized." }
+        builder.loggingSeverity?.also { Logging.logToDebug(it) }
+        _peerConnectionFactory = builder.factoryBuilder?.let { nnFactoryBuilder ->
+            PeerConnectionFactory().apply(nnFactoryBuilder)
+        } ?: PeerConnectionFactory()
+    }
+
+    actual fun dispose() {
+        if (_peerConnectionFactory == null) return
+        _peerConnectionFactory?.dispose()
+        _peerConnectionFactory = null
+    }
+}
+
+class WebRtcBuilder(
+    var factoryBuilder: (PeerConnectionFactory.() -> Unit)? = null,
+    var loggingSeverity: Logging.Severity? = null,
+)
+
+@Deprecated(
+    "Use WebRtc.initialize()",
+    replaceWith = ReplaceWith("WebRtc.initialize()")
+)
+fun initializeWebRtc(
+    build: WebRtcBuilder.() -> Unit = {}
+) {
+    WebRtc.configureBuilder(build)
+    WebRtc.initialize()
+}

--- a/webrtc-kmp/src/jvmTest/kotlin/com/shepeliev/webrtckmp/TestUtils.kt
+++ b/webrtc-kmp/src/jvmTest/kotlin/com/shepeliev/webrtckmp/TestUtils.kt
@@ -1,0 +1,17 @@
+package com.shepeliev.webrtckmp
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+actual inline fun runTest(
+    timeout: Long,
+    crossinline block: suspend CoroutineScope.() -> Unit,
+) {
+    runBlocking {
+        withTimeout(timeout) {
+            coroutineScope { block() }
+        }
+    }
+}


### PR DESCRIPTION
Inspired by https://github.com/shepeliev/webrtc-kmp/pull/73, here's my attempt to provide `JVM` (Desktop) support for this library. The work is not done yet, I'm yet to write a sample and complete the implementation of `MediaDevices` but I'm raising this draft PR so that I could get some feedback on the work I've done so far.

Feel free to drop comments on how I could improve the code.

I'm planning to use the [Realm Kotlin SDK](https://www.mongodb.com/docs/realm/sdk/kotlin/) and MongoDB for the DataSource in the JVM sample as Firebase is not available for Desktop. Feel free to suggest any better alternatives as we just need to write a barebones sample app.

I have also raised issues for the problems I'm facing while trying to implement `MediaDevices` (https://github.com/devopvoid/webrtc-java/issues/114) and `DtmfSender` (https://github.com/devopvoid/webrtc-java/issues/115)