### PR TITLE
Fixed : sample app creates crash on hangup after "joined" 

### DIFF
--- a/sample/shared/src/commonMain/kotlin/com/shepeliev/webrtckmp/sample/shared/RoomComponent.kt
+++ b/sample/shared/src/commonMain/kotlin/com/shepeliev/webrtckmp/sample/shared/RoomComponent.kt
@@ -18,6 +18,7 @@ import com.shepeliev.webrtckmp.IceServer
 import com.shepeliev.webrtckmp.MediaDevices
 import com.shepeliev.webrtckmp.MediaStreamTrack
 import com.shepeliev.webrtckmp.MediaStreamTrackKind
+import com.shepeliev.webrtckmp.MediaStreamTrackState
 import com.shepeliev.webrtckmp.OfferAnswerOptions
 import com.shepeliev.webrtckmp.PeerConnection
 import com.shepeliev.webrtckmp.RtcConfiguration
@@ -194,6 +195,7 @@ class RoomComponent(
 
         private fun listenTrackState(track: MediaStreamTrack, logPrefix: String) {
             track.state
+                .filter { it is MediaStreamTrackState.Live }
                 .onEach { logger.w { "$logPrefix track [id = ${track.id}] state changed: $it" } }
                 .launchIn(scope + roomSessionJob!!)
         }


### PR DESCRIPTION

Fixed : sample app creates crash on hangup after "joined"  because mediaStreamTrack state is "Ended" and MediaStreamTrack has been disposed.
This PR solves this small bug in sample app.

Steps to reproduce the bug :
1. USER A create Room
2. USER B joined the Room
3. USER B hangup the call.
4. Crashes

Android Version : 12
Device : Oneplus