### PR TITLE
fix: DataChannel not emitting new data on iOS

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.wasm.enabled=true
 
 # Versions
-webRtcKmpVersion=0.125.0
+webRtcKmpVersion=0.125.1

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/NSData.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/NSData.kt
@@ -2,6 +2,7 @@
 
 package com.shepeliev.webrtckmp
 
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.memScoped
@@ -11,6 +12,7 @@ import platform.Foundation.NSData
 import platform.Foundation.create
 import platform.posix.memcpy
 
+@BetaInteropApi
 internal fun ByteArray.toNSData(): NSData = memScoped {
     NSData.create(bytes = this@toNSData.toCValues().ptr, length = size.toULong())
 }

--- a/webrtc-kmp/webrtc_kmp.podspec
+++ b/webrtc-kmp/webrtc_kmp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'webrtc_kmp'
-    spec.version                  = '0.125.0'
+    spec.version                  = '0.125.1'
     spec.homepage                 = 'https://github.com/shepeliev/webrtc-kmp'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
## Problem
In our project, we use data channels to notify other peers that some state has changed (mic, camera, and other stuff)

On iOS, data channels work for 4-5s after the connection is established then they stop emitting data in `onMessage` flow, while sending data still works properly (Only receiving data was broken)

After digging a little deeper in the app, I found out that my collectors (subscription to data flow) are always active, they just don't receive anything. This applies to all flows (`onMessage`, `onClose`...)

It seemed like an internal problem in `webrtc`, so I cloned the library and started logging and making some changes. I found out that the `delegate` stops receiving callbacks after a short time, which looks like something is reassigning it, or it's getting cleared somewhere.

## Solution
This solution might be weird, but it works. Before making these changes, I could repeat the problem 10 times out of 10, but after the changes, I couldn't repeat it anymore.

I think having a strong reference of the delegate prevents it from being cleared, therefore it's always active.

I would love to hear your thoughts on this :)