### PR TITLE
Refactor configuring the lib

### DIFF
--- a/sample/composeApp/src/androidMain/kotlin/com/shepeliev/webrtckmp/sample/MainActivity.kt
+++ b/sample/composeApp/src/androidMain/kotlin/com/shepeliev/webrtckmp/sample/MainActivity.kt
@@ -18,8 +18,7 @@ class MainActivity : ComponentActivity() {
 
         val initializationOptions = PeerConnectionFactory.InitializationOptions.builder(this)
             .setInjectableLogger(WebRtcLogger, Logging.Severity.LS_ERROR)
-            .createInitializationOptions()
-        WebRtc.configurePeerConnectionFactory(peerConnectionFactoryInitializationOptions = initializationOptions)
+        WebRtc.configure(peerConnectionInitializationOptionsBuilder = initializationOptions)
 
         setContent {
             App()
@@ -34,9 +33,7 @@ private object WebRtcLogger : Loggable {
             Logging.Severity.LS_WARNING -> Log.w(tag, message)
             Logging.Severity.LS_INFO -> Log.i(tag, message)
             Logging.Severity.LS_VERBOSE -> Log.v(tag, message)
-            Logging.Severity.LS_NONE -> {
-
-            }
+            Logging.Severity.LS_NONE -> {}
         }
     }
 }

--- a/sample/composeApp/src/androidMain/kotlin/com/shepeliev/webrtckmp/sample/MainActivity.kt
+++ b/sample/composeApp/src/androidMain/kotlin/com/shepeliev/webrtckmp/sample/MainActivity.kt
@@ -10,15 +10,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.shepeliev.webrtckmp.WebRtc
 import org.webrtc.Loggable
 import org.webrtc.Logging
-import org.webrtc.PeerConnectionFactory
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val initializationOptions = PeerConnectionFactory.InitializationOptions.builder(this)
+        val initializationOptionsBuilder = WebRtc.createInitializationOptionsBuilder()
             .setInjectableLogger(WebRtcLogger, Logging.Severity.LS_ERROR)
-        WebRtc.configure(peerConnectionInitializationOptionsBuilder = initializationOptions)
+        val peerConnectionFactoryBuilder = WebRtc.createPeerConnectionFactoryBuilder(initializationOptionsBuilder)
+        WebRtc.configure(peerConnectionFactoryBuilder = peerConnectionFactoryBuilder)
 
         setContent {
             App()

--- a/sample/iosApp/iosApp/iOSApp.swift
+++ b/sample/iosApp/iosApp/iOSApp.swift
@@ -10,6 +10,6 @@ struct iOSApp: App {
 	}
     
     init() {
-        WebRtc.shared.configure(loggingSeverity: .rtcloggingseveritywarning)
+        WebRtc.shared.configure(loggingSeverity: .rtcloggingseverityinfo)
     }
 }

--- a/sample/iosApp/iosApp/iOSApp.swift
+++ b/sample/iosApp/iosApp/iOSApp.swift
@@ -10,6 +10,6 @@ struct iOSApp: App {
 	}
     
     init() {
-        WebRtc.shared.configurePeerConnectionFactory(loggingSeverity: .rtcloggingseveritywarning)
+        WebRtc.shared.configure(loggingSeverity: .rtcloggingseveritywarning)
     }
 }

--- a/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
+++ b/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
@@ -11,10 +11,6 @@ import org.webrtc.DefaultVideoEncoderFactory
 import org.webrtc.EglBase
 import org.webrtc.PeerConnectionFactory
 import org.webrtc.PeerConnectionFactory.InitializationOptions
-import org.webrtc.PeerConnectionFactory.Options
-import org.webrtc.VideoDecoderFactory
-import org.webrtc.VideoEncoderFactory
-import org.webrtc.audio.AudioDeviceModule
 
 @Suppress("MemberVisibilityCanBePrivate")
 object WebRtc {
@@ -22,12 +18,6 @@ object WebRtc {
     val rootEglBase: EglBase by lazy {
         _rootEglBase ?: EglBase.create().also { _rootEglBase = it }
     }
-
-    private var factoryInitializationOptions: InitializationOptions? = null
-    private var options: Options? = null
-    private var audioDeviceModule: AudioDeviceModule? = null
-    private var videoEncoderFactory: VideoEncoderFactory? = null
-    private var videoDecoderFactory: VideoDecoderFactory? = null
 
     internal lateinit var applicationContext: Context
         private set
@@ -44,47 +34,64 @@ object WebRtc {
         }
     }
 
+    private var _peerConnectionFactory: PeerConnectionFactory? = null
     internal val peerConnectionFactory: PeerConnectionFactory by lazy {
-        val initializationOptions = factoryInitializationOptions
-            ?: InitializationOptions.builder(applicationContext).createInitializationOptions()
-        PeerConnectionFactory.initialize(initializationOptions)
-
-        PeerConnectionFactory.builder()
-            .setOptions(options)
-            .setAudioDeviceModule(audioDeviceModule)
-            .setVideoDecoderFactory(videoDecoderFactory ?: DefaultVideoDecoderFactory(rootEglBase.eglBaseContext))
-            .setVideoEncoderFactory(
-                videoEncoderFactory ?: DefaultVideoEncoderFactory(rootEglBase.eglBaseContext, true, true)
-            )
-            .createPeerConnectionFactory()
+        _peerConnectionFactory ?: createPeerConnectionFactory(
+            defaultPeerConnectionFactoryInitializationOptionsBuilder(),
+            defaultPeerConnectionBuilder()
+        ).also { _peerConnectionFactory = it }
     }
 
     @Suppress("unused")
-    fun configurePeerConnectionFactory(
+    fun configure(
         rootEglBase: EglBase? = null,
-        peerConnectionFactoryInitializationOptions: InitializationOptions? = null,
-        options: Options? = null,
-        audioDeviceModule: AudioDeviceModule? = null,
-        videoEncoderFactory: VideoEncoderFactory? = null,
-        videoDecoderFactory: VideoDecoderFactory? = null,
-        cameraEnumerator: CameraEnumerator? = null,
         videoProcessorFactory: VideoProcessorFactory? = null,
+        cameraEnumerator: CameraEnumerator? = null,
+        peerConnectionInitializationOptionsBuilder: InitializationOptions.Builder = defaultPeerConnectionFactoryInitializationOptionsBuilder(),
+        peerConnectionFactoryBuilder: PeerConnectionFactory.Builder = defaultPeerConnectionBuilder(),
     ) {
-        check(_rootEglBase == null) {
+        check(_peerConnectionFactory == null) {
             "WebRtc.configurePeerConnectionFactory() must be called once only and before any access to MediaDevices."
         }
 
-        this._rootEglBase = rootEglBase ?: EglBase.create()
-        this.factoryInitializationOptions = peerConnectionFactoryInitializationOptions
-        this.options = options
-        this.audioDeviceModule = audioDeviceModule
-        this.videoEncoderFactory = videoEncoderFactory
-        this.videoDecoderFactory = videoDecoderFactory
-        this._cameraEnumerator = cameraEnumerator
+        if (rootEglBase != null) {
+            check(_rootEglBase == null) { "Root EglBase is already initialized." }
+            _rootEglBase = rootEglBase
+        }
+
         this.videoProcessorFactory = videoProcessorFactory
+        _cameraEnumerator = cameraEnumerator
+        _peerConnectionFactory = createPeerConnectionFactory(
+            peerConnectionInitializationOptionsBuilder,
+            peerConnectionFactoryBuilder
+        )
     }
 
     internal fun initializeApplicationContext(context: Context) {
         applicationContext = context.applicationContext
+    }
+
+    private fun createPeerConnectionFactory(
+        peerConnectionInitializationOptionsBuilder: InitializationOptions.Builder,
+        peerConnectionFactoryBuilder: PeerConnectionFactory.Builder
+    ): PeerConnectionFactory {
+        PeerConnectionFactory.initialize(peerConnectionInitializationOptionsBuilder.createInitializationOptions())
+        return peerConnectionFactoryBuilder.createPeerConnectionFactory()
+    }
+
+    private fun defaultPeerConnectionFactoryInitializationOptionsBuilder(): InitializationOptions.Builder {
+        return InitializationOptions.builder(applicationContext)
+    }
+
+    private fun defaultPeerConnectionBuilder(): PeerConnectionFactory.Builder {
+        return PeerConnectionFactory.builder()
+            .setVideoDecoderFactory(DefaultVideoDecoderFactory(rootEglBase.eglBaseContext))
+            .setVideoEncoderFactory(
+                DefaultVideoEncoderFactory(
+                    rootEglBase.eglBaseContext,
+                    true,
+                    true
+                )
+            )
     }
 }

--- a/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
+++ b/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
@@ -11,10 +11,15 @@ import org.webrtc.DefaultVideoEncoderFactory
 import org.webrtc.EglBase
 import org.webrtc.PeerConnectionFactory
 import org.webrtc.PeerConnectionFactory.InitializationOptions
+import org.webrtc.VideoProcessor
 
 @Suppress("MemberVisibilityCanBePrivate")
 object WebRtc {
     private var _rootEglBase: EglBase? = null
+
+    /**
+     * The root [EglBase] instance.
+     */
     val rootEglBase: EglBase by lazy {
         _rootEglBase ?: EglBase.create().also { _rootEglBase = it }
     }
@@ -36,19 +41,56 @@ object WebRtc {
 
     private var _peerConnectionFactory: PeerConnectionFactory? = null
     internal val peerConnectionFactory: PeerConnectionFactory by lazy {
-        _peerConnectionFactory ?: createPeerConnectionFactory(
-            defaultPeerConnectionFactoryInitializationOptionsBuilder(),
-            defaultPeerConnectionBuilder()
-        ).also { _peerConnectionFactory = it }
+        _peerConnectionFactory ?: createPeerConnectionFactoryBuilder().createPeerConnectionFactory()
+            .also { _peerConnectionFactory = it }
     }
 
+    /**
+     * Creates a new default [InitializationOptions.Builder].
+     */
+    fun createInitializationOptionsBuilder(): InitializationOptions.Builder {
+        return InitializationOptions.builder(applicationContext)
+    }
+
+    /**
+     * Creates a new default [PeerConnectionFactory.Builder].
+     */
+    fun createPeerConnectionFactoryBuilder(
+        initializationOptionsBuilder: InitializationOptions.Builder = createInitializationOptionsBuilder(),
+        enableIntelVp8Encoder: Boolean = true,
+        enableH264HighProfile: Boolean = true
+    ): PeerConnectionFactory.Builder {
+        PeerConnectionFactory.initialize(initializationOptionsBuilder.createInitializationOptions())
+
+        val videoDecoderFactory = DefaultVideoDecoderFactory(rootEglBase.eglBaseContext)
+        val defaultVideoEncoderFactory = DefaultVideoEncoderFactory(
+            rootEglBase.eglBaseContext,
+            enableIntelVp8Encoder,
+            enableH264HighProfile
+        )
+        return PeerConnectionFactory.builder()
+            .setVideoDecoderFactory(videoDecoderFactory)
+            .setVideoEncoderFactory(defaultVideoEncoderFactory)
+    }
+
+    /**
+     * Configures the WebRTC library. This method must be called once only and before any access to
+     * MediaDevices.
+     *
+     * @param rootEglBase The root [EglBase] instance. If not provided, a new instance will be
+     * created.
+     * @param videoProcessorFactory The factory to create [VideoProcessor] instances.
+     * @param cameraEnumerator The camera enumerator to use. If not provided, the default enumerator
+     * will be used.
+     * @param peerConnectionFactoryBuilder The [PeerConnectionFactory.Builder] to use for creating
+     * [PeerConnectionFactory].
+     */
     @Suppress("unused")
     fun configure(
         rootEglBase: EglBase? = null,
         videoProcessorFactory: VideoProcessorFactory? = null,
         cameraEnumerator: CameraEnumerator? = null,
-        peerConnectionInitializationOptionsBuilder: InitializationOptions.Builder = defaultPeerConnectionFactoryInitializationOptionsBuilder(),
-        peerConnectionFactoryBuilder: PeerConnectionFactory.Builder = defaultPeerConnectionBuilder(),
+        peerConnectionFactoryBuilder: PeerConnectionFactory.Builder = createPeerConnectionFactoryBuilder(),
     ) {
         check(_peerConnectionFactory == null) {
             "WebRtc.configurePeerConnectionFactory() must be called once only and before any access to MediaDevices."
@@ -61,37 +103,10 @@ object WebRtc {
 
         this.videoProcessorFactory = videoProcessorFactory
         _cameraEnumerator = cameraEnumerator
-        _peerConnectionFactory = createPeerConnectionFactory(
-            peerConnectionInitializationOptionsBuilder,
-            peerConnectionFactoryBuilder
-        )
+        _peerConnectionFactory = peerConnectionFactoryBuilder.createPeerConnectionFactory()
     }
 
     internal fun initializeApplicationContext(context: Context) {
         applicationContext = context.applicationContext
-    }
-
-    private fun createPeerConnectionFactory(
-        peerConnectionInitializationOptionsBuilder: InitializationOptions.Builder,
-        peerConnectionFactoryBuilder: PeerConnectionFactory.Builder
-    ): PeerConnectionFactory {
-        PeerConnectionFactory.initialize(peerConnectionInitializationOptionsBuilder.createInitializationOptions())
-        return peerConnectionFactoryBuilder.createPeerConnectionFactory()
-    }
-
-    private fun defaultPeerConnectionFactoryInitializationOptionsBuilder(): InitializationOptions.Builder {
-        return InitializationOptions.builder(applicationContext)
-    }
-
-    private fun defaultPeerConnectionBuilder(): PeerConnectionFactory.Builder {
-        return PeerConnectionFactory.builder()
-            .setVideoDecoderFactory(DefaultVideoDecoderFactory(rootEglBase.eglBaseContext))
-            .setVideoEncoderFactory(
-                DefaultVideoEncoderFactory(
-                    rootEglBase.eglBaseContext,
-                    true,
-                    true
-                )
-            )
     }
 }

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
@@ -1,355 +1,139 @@
 package com.shepeliev.webrtckmp
 
-import WebRTC.RTCDefaultVideoDecoderFactory
-import WebRTC.RTCDefaultVideoEncoderFactory
 import WebRTC.RTCInitializeSSL
 import WebRTC.RTCLoggingSeverity
 import WebRTC.RTCPeerConnectionFactory
-import WebRTC.RTCPeerConnectionFactoryOptions
 import WebRTC.RTCSetMinDebugLogLevel
-import WebRTC.RTCVideoDecoderFactoryProtocol
-import WebRTC.RTCVideoEncoderFactoryProtocol
 import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
 object WebRtc {
-    private var videoEncoderFactory: RTCVideoEncoderFactoryProtocol? = null
-    private var videoDecoderFactory: RTCVideoDecoderFactoryProtocol? = null
-    private var peerConnectionFactoryOptions: RTCPeerConnectionFactoryOptions? = null
-    private var loggingSeverity: RTCLoggingSeverity? = null
-
     internal var videoProcessorFactory: VideoProcessorFactory? = null
         private set
 
     private var _peerConnectionFactory: RTCPeerConnectionFactory? = null
-    internal val peerConnectionFactory: RTCPeerConnectionFactory
-        get() = _peerConnectionFactory ?: createPeerConnectionFactory().also { _peerConnectionFactory = it }
+    internal val peerConnectionFactory: RTCPeerConnectionFactory by lazy {
+        _peerConnectionFactory ?: run {
+            initialize()
+            RTCPeerConnectionFactory().also { _peerConnectionFactory = it }
+        }
+    }
 
     /**
      * The name of the bundled video file to use as a fallback for the camera in the iOS simulator.
      */
     var simulatorCameraFallbackFileName: String = "simulator-camera.mp4"
 
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(loggingSeverity: RTCLoggingSeverity) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, null, null, null, null)
+    /**
+     * Configures the WebRTC KMP library with the specified parameters.
+     *
+     * @param loggingSeverity The severity of the logging output.
+     */
+    fun configure(loggingSeverity: RTCLoggingSeverity) {
+        configurePeerConnectionFactoryInternal(loggingSeverity = loggingSeverity)
     }
 
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(videoEncoderFactory: RTCVideoEncoderFactoryProtocol) {
-        configurePeerConnectionFactoryInternal(null, videoEncoderFactory, null, null, null)
+    /**
+     * Configures the WebRTC KMP library with the specified parameters.
+     *
+     * @param videoProcessorFactory The factory to create video processors.
+     */
+    fun configure(videoProcessorFactory: VideoProcessorFactory) {
+        configurePeerConnectionFactoryInternal(videoProcessorFactory = videoProcessorFactory)
     }
 
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(videoDecoderFactory: RTCVideoDecoderFactoryProtocol) {
-        configurePeerConnectionFactoryInternal(null, null, videoDecoderFactory, null, null)
+    /**
+     * Configures the WebRTC KMP library with the specified parameters.
+     *
+     * @param rtcPeerConnectionFactory The peer connection factory to use.
+     */
+    fun configure(rtcPeerConnectionFactory: RTCPeerConnectionFactory) {
+        configurePeerConnectionFactoryInternal(rtcPeerConnectionFactory = rtcPeerConnectionFactory)
     }
 
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(options: RTCPeerConnectionFactoryOptions) {
-        configurePeerConnectionFactoryInternal(null, null, null, options, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(null, null, null, null, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
+    /**
+     * Configures the WebRTC KMP library with the specified parameters.
+     *
+     * @param loggingSeverity The severity of the logging output.
+     * @param videoProcessorFactory The factory to create video processors.
+     */
+    fun configure(
         loggingSeverity: RTCLoggingSeverity,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, videoEncoderFactory, null, null, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, null, videoDecoderFactory, null, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        options: RTCPeerConnectionFactoryOptions
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, null, null, options, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, null, null, null, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol
-    ) {
-        configurePeerConnectionFactoryInternal(null, videoEncoderFactory, videoDecoderFactory, null, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions
-    ) {
-        configurePeerConnectionFactoryInternal(null, videoEncoderFactory, null, options, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(null, videoEncoderFactory, null, null, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions
-    ) {
-        configurePeerConnectionFactoryInternal(null, null, videoDecoderFactory, options, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(null, null, videoDecoderFactory, null, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        options: RTCPeerConnectionFactoryOptions,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(null, null, null, options, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, videoEncoderFactory, videoDecoderFactory, null, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, videoEncoderFactory, null, options, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, videoEncoderFactory, null, null, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, null, videoDecoderFactory, options, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, null, videoDecoderFactory, null, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        options: RTCPeerConnectionFactoryOptions,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, null, null, options, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions
-    ) {
-        configurePeerConnectionFactoryInternal(null, videoEncoderFactory, videoDecoderFactory, options, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(
-            null,
-            videoEncoderFactory,
-            videoDecoderFactory,
-            null,
-            videoProcessorFactory
-        )
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(null, videoEncoderFactory, null, options, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(null, null, videoDecoderFactory, options, videoProcessorFactory)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions
-    ) {
-        configurePeerConnectionFactoryInternal(loggingSeverity, videoEncoderFactory, videoDecoderFactory, options, null)
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(
-            loggingSeverity,
-            videoEncoderFactory,
-            videoDecoderFactory,
-            null,
-            videoProcessorFactory
-        )
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(
-            loggingSeverity,
-            videoEncoderFactory,
-            null,
-            options,
-            videoProcessorFactory
-        )
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(
-            loggingSeverity,
-            null,
-            videoDecoderFactory,
-            options,
-            videoProcessorFactory
-        )
-    }
-
-    @Suppress("unused")
-    fun configurePeerConnectionFactory(
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions,
-        videoProcessorFactory: VideoProcessorFactory
-    ) {
-        configurePeerConnectionFactoryInternal(
-            null,
-            videoEncoderFactory,
-            videoDecoderFactory,
-            options,
-            videoProcessorFactory
-        )
-    }
-
-    @Suppress("unused")
-    private fun configurePeerConnectionFactory(
-        loggingSeverity: RTCLoggingSeverity,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol,
-        options: RTCPeerConnectionFactoryOptions,
         videoProcessorFactory: VideoProcessorFactory,
     ) {
         configurePeerConnectionFactoryInternal(
-            loggingSeverity,
-            videoEncoderFactory,
-            videoDecoderFactory,
-            options,
-            videoProcessorFactory
+            loggingSeverity = loggingSeverity,
+            videoProcessorFactory = videoProcessorFactory
+        )
+    }
+
+    /**
+     * Configures the WebRTC KMP library with the specified parameters.
+     *
+     * @param loggingSeverity The severity of the logging output.
+     * @param rtcPeerConnectionFactory The peer connection factory to use.
+     */
+    fun configure(
+        loggingSeverity: RTCLoggingSeverity,
+        rtcPeerConnectionFactory: RTCPeerConnectionFactory,
+    ) {
+        configurePeerConnectionFactoryInternal(
+            loggingSeverity = loggingSeverity,
+            rtcPeerConnectionFactory = rtcPeerConnectionFactory
+        )
+    }
+
+    /**
+     * Configures the WebRTC KMP library with the specified parameters.
+     *
+     * @param videoProcessorFactory The factory to create video processors.
+     * @param rtcPeerConnectionFactory The peer connection factory to use.
+     */
+    fun configure(
+        videoProcessorFactory: VideoProcessorFactory,
+        rtcPeerConnectionFactory: RTCPeerConnectionFactory,
+    ) {
+        configurePeerConnectionFactoryInternal(
+            videoProcessorFactory = videoProcessorFactory,
+            rtcPeerConnectionFactory = rtcPeerConnectionFactory
+        )
+    }
+
+    /**
+     * Configures the WebRTC KMP library with the specified parameters.
+     *
+     * @param loggingSeverity The severity of the logging output.
+     * @param videoProcessorFactory The factory to create video processors.
+     * @param rtcPeerConnectionFactory The peer connection factory to use.
+     */
+    fun configure(
+        loggingSeverity: RTCLoggingSeverity,
+        videoProcessorFactory: VideoProcessorFactory,
+        rtcPeerConnectionFactory: RTCPeerConnectionFactory,
+    ) {
+        configurePeerConnectionFactoryInternal(
+            loggingSeverity = loggingSeverity,
+            videoProcessorFactory = videoProcessorFactory,
+            rtcPeerConnectionFactory = rtcPeerConnectionFactory,
         )
     }
 
     private fun configurePeerConnectionFactoryInternal(
-        loggingSeverity: RTCLoggingSeverity?,
-        videoEncoderFactory: RTCVideoEncoderFactoryProtocol?,
-        videoDecoderFactory: RTCVideoDecoderFactoryProtocol?,
-        options: RTCPeerConnectionFactoryOptions?,
-        videoProcessorFactory: VideoProcessorFactory?,
+        loggingSeverity: RTCLoggingSeverity? = null,
+        videoProcessorFactory: VideoProcessorFactory? = null,
+        rtcPeerConnectionFactory: RTCPeerConnectionFactory? = null,
     ) {
         check(_peerConnectionFactory == null) {
-            "WebRtc.configurePeerConnectionFactory() must be called once only and before any access to MediaDevices."
+            "WebRtc.configure() must be called once only and before any access to MediaDevices."
         }
 
-        this.loggingSeverity = loggingSeverity
-        this.videoEncoderFactory = videoEncoderFactory
-        this.videoDecoderFactory = videoDecoderFactory
-        this.peerConnectionFactoryOptions = options
         this.videoProcessorFactory = videoProcessorFactory
-        _peerConnectionFactory = createPeerConnectionFactory()
+        _peerConnectionFactory = rtcPeerConnectionFactory
+        initialize(loggingSeverity)
     }
 
-    private fun createPeerConnectionFactory(): RTCPeerConnectionFactory {
+    private fun initialize(loggingSeverity: RTCLoggingSeverity? = null) {
         RTCInitializeSSL()
         loggingSeverity?.let { RTCSetMinDebugLogLevel(it) }
-        val encoderFactory = videoEncoderFactory ?: RTCDefaultVideoEncoderFactory()
-        val decoderFactory = videoDecoderFactory ?: RTCDefaultVideoDecoderFactory()
-        val factory = RTCPeerConnectionFactory(encoderFactory, decoderFactory)
-        peerConnectionFactoryOptions?.let { factory.setOptions(it) }
-        return factory
     }
 }

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/WebRtc.kt
@@ -30,7 +30,7 @@ object WebRtc {
      * @param loggingSeverity The severity of the logging output.
      */
     fun configure(loggingSeverity: RTCLoggingSeverity) {
-        configurePeerConnectionFactoryInternal(loggingSeverity = loggingSeverity)
+        configureInternal(loggingSeverity = loggingSeverity)
     }
 
     /**
@@ -39,7 +39,7 @@ object WebRtc {
      * @param videoProcessorFactory The factory to create video processors.
      */
     fun configure(videoProcessorFactory: VideoProcessorFactory) {
-        configurePeerConnectionFactoryInternal(videoProcessorFactory = videoProcessorFactory)
+        configureInternal(videoProcessorFactory = videoProcessorFactory)
     }
 
     /**
@@ -48,7 +48,7 @@ object WebRtc {
      * @param rtcPeerConnectionFactory The peer connection factory to use.
      */
     fun configure(rtcPeerConnectionFactory: RTCPeerConnectionFactory) {
-        configurePeerConnectionFactoryInternal(rtcPeerConnectionFactory = rtcPeerConnectionFactory)
+        configureInternal(rtcPeerConnectionFactory = rtcPeerConnectionFactory)
     }
 
     /**
@@ -61,7 +61,7 @@ object WebRtc {
         loggingSeverity: RTCLoggingSeverity,
         videoProcessorFactory: VideoProcessorFactory,
     ) {
-        configurePeerConnectionFactoryInternal(
+        configureInternal(
             loggingSeverity = loggingSeverity,
             videoProcessorFactory = videoProcessorFactory
         )
@@ -77,7 +77,7 @@ object WebRtc {
         loggingSeverity: RTCLoggingSeverity,
         rtcPeerConnectionFactory: RTCPeerConnectionFactory,
     ) {
-        configurePeerConnectionFactoryInternal(
+        configureInternal(
             loggingSeverity = loggingSeverity,
             rtcPeerConnectionFactory = rtcPeerConnectionFactory
         )
@@ -93,7 +93,7 @@ object WebRtc {
         videoProcessorFactory: VideoProcessorFactory,
         rtcPeerConnectionFactory: RTCPeerConnectionFactory,
     ) {
-        configurePeerConnectionFactoryInternal(
+        configureInternal(
             videoProcessorFactory = videoProcessorFactory,
             rtcPeerConnectionFactory = rtcPeerConnectionFactory
         )
@@ -111,14 +111,14 @@ object WebRtc {
         videoProcessorFactory: VideoProcessorFactory,
         rtcPeerConnectionFactory: RTCPeerConnectionFactory,
     ) {
-        configurePeerConnectionFactoryInternal(
+        configureInternal(
             loggingSeverity = loggingSeverity,
             videoProcessorFactory = videoProcessorFactory,
             rtcPeerConnectionFactory = rtcPeerConnectionFactory,
         )
     }
 
-    private fun configurePeerConnectionFactoryInternal(
+    private fun configureInternal(
         loggingSeverity: RTCLoggingSeverity? = null,
         videoProcessorFactory: VideoProcessorFactory? = null,
         rtcPeerConnectionFactory: RTCPeerConnectionFactory? = null,


### PR DESCRIPTION
In order to make `PeerConnectionFactory` customization more flexible I've refactored the lib configuration.

### Android
`PeerConnectionFactory` is customized by `PeerConnectionFactory.Builder` that is passed to `WebRtc.configure()`

```kotlin
val loggable = Loggable { message, severity, tag ->
    Logger.withTag(tag).also { logger ->
        when (severity) {
            Logging.Severity.LS_VERBOSE -> logger.d { message }
            Logging.Severity.LS_INFO -> logger.i { message }
            Logging.Severity.LS_WARNING -> logger.w { message }
            Logging.Severity.LS_ERROR -> logger.e { message }
            else -> logger.v { message }
         }
    }
}
val severity = if (BuildConfig.DEBUG) Logging.Severity.LS_INFO else Logging.Severity.LS_ERROR

val initializationOptionsBuilder = WebRtc.createInitializationOptionsBuilder()
    .setInjectableLogger(loggable, severity)
val peerConnectionFactoryBuilder WebRtc.createPeerConnectionFactoryBuilder(initializationOptionsBuilder)
    .setAudioDeviceModule(audioDeviceModule)
WebRtc.configure(
     videoProcessorFactory = { videoProcessor },
     peerConnectionFactoryBuilder = peerConnectionFactoryBuilder,
)
```

### iOS
Custom `RTCPeerConnectionFactory` may be passed to `WebRtc.configure()`

```swift
let audioProcessingModule = RTCDefaultAudioProcessingModule()
audioProcessingModule.renderPreProcessingDelegate = audioProcessor
        
let peerConnectionFactory = RTCPeerConnectionFactory(
    bypassVoiceProcessing: true,
    encoderFactory: RTCDefaultVideoEncoderFactory(),
    decoderFactory: RTCDefaultVideoDecoderFactory(),
    audioProcessingModule: audioProcessingModule
)
WebRtc.shared.configure(
     loggingSeverity: .rtcloggingSeverityWarning,
     videoProcessorFactory: videoProcessor,
     rtcPeerConnectionFactory: peerConnectionFactory
)
```