### PR TITLE
Making native (iOS&Android) audio volume control accessible in AudioStreamTrack

### DIFF
--- a/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/LocalAudioStreamTrack.kt
+++ b/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/LocalAudioStreamTrack.kt
@@ -12,4 +12,8 @@ internal class LocalAudioStreamTrack(
     override fun onStop() {
         audioSource.dispose()
     }
+
+    override fun setVolume(volume: Double) {
+        (android as AudioTrack).setVolume(volume)
+    }
 }

--- a/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/RemoteAudioStreamTrack.kt
+++ b/webrtc-kmp/src/androidMain/kotlin/com/shepeliev/webrtckmp/RemoteAudioStreamTrack.kt
@@ -4,4 +4,9 @@ import org.webrtc.AudioTrack
 
 internal class RemoteAudioStreamTrack(
     android: AudioTrack
-) : MediaStreamTrackImpl(android), AudioStreamTrack
+) : MediaStreamTrackImpl(android), AudioStreamTrack {
+
+    override fun setVolume(volume: Double) {
+        (android as AudioTrack).setVolume(volume)
+    }
+}

--- a/webrtc-kmp/src/commonMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
+++ b/webrtc-kmp/src/commonMain/kotlin/com/shepeliev/webrtckmp/AudioStreamTrack.kt
@@ -1,3 +1,5 @@
 package com.shepeliev.webrtckmp
 
-interface AudioStreamTrack : MediaStreamTrack
+interface AudioStreamTrack : MediaStreamTrack {
+    fun setVolume(volume: Double)
+}

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/LocalAudioStreamTrack.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/LocalAudioStreamTrack.kt
@@ -8,4 +8,8 @@ import kotlinx.cinterop.ExperimentalForeignApi
 internal class LocalAudioStreamTrack(
     ios: RTCAudioTrack,
     override val constraints: MediaTrackConstraints,
-) : MediaStreamTrackImpl(ios), AudioStreamTrack
+) : MediaStreamTrackImpl(ios), AudioStreamTrack {
+    override fun setVolume(volume: Double) {
+        (ios as RTCAudioTrack).source.setVolume(volume)
+    }
+}

--- a/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/RemoteAudioStreamTrack.kt
+++ b/webrtc-kmp/src/iosMain/kotlin/com/shepeliev/webrtckmp/RemoteAudioStreamTrack.kt
@@ -7,4 +7,8 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 internal class RemoteAudioStreamTrack(
     ios: RTCAudioTrack
-) : MediaStreamTrackImpl(ios), AudioStreamTrack
+) : MediaStreamTrackImpl(ios), AudioStreamTrack {
+    override fun setVolume(volume: Double) {
+        (ios as RTCAudioTrack).source().setVolume(volume)
+    }
+}

--- a/webrtc-kmp/src/jsAndWasmJsMain/kotlin/com/shepeliev/webrtckmp/internal/AudioTrackImpl.kt
+++ b/webrtc-kmp/src/jsAndWasmJsMain/kotlin/com/shepeliev/webrtckmp/internal/AudioTrackImpl.kt
@@ -4,4 +4,10 @@ import com.shepeliev.webrtckmp.AudioStreamTrack
 import com.shepeliev.webrtckmp.MediaStreamTrackImpl
 import com.shepeliev.webrtckmp.externals.PlatformMediaStreamTrack
 
-internal class AudioTrackImpl(platform: PlatformMediaStreamTrack) : MediaStreamTrackImpl(platform), AudioStreamTrack
+internal class AudioTrackImpl(platform: PlatformMediaStreamTrack) : MediaStreamTrackImpl(platform),
+    AudioStreamTrack {
+
+    override fun setVolume(volume: Double) {
+        // not available in JS
+    }
+}


### PR DESCRIPTION
Added method setVolume(volume: Double) to AudioStreamTrack interface and also added the iOS and Android platform-dependent implementations. JS "implementation" is empty, because corresponding native call is not available