### PR TITLE
Set AGP version to v8.9.3, Android compile SDK to 35

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,22 +16,22 @@ if (localPropertiesFile.exists()) {
 }
 
 val signingKey by extra(
-    localProps.getOrDefault("signing.key", System.getenv("SIGNING_KEY") ?: "")
+    localProps.getOrDefault("signing.key", System.getenv("SIGNING_KEY") ?: ""),
 )
 val signingPassword by extra(
-    localProps.getOrDefault("signing.password", System.getenv("SIGNING_PASSWORD") ?: "")
+    localProps.getOrDefault("signing.password", System.getenv("SIGNING_PASSWORD") ?: ""),
 )
 val ossrhUsername by extra(
-    localProps.getOrDefault("ossrhUsername", System.getenv("OSSRH_USERNAME") ?: "")
+    localProps.getOrDefault("ossrhUsername", System.getenv("OSSRH_USERNAME") ?: ""),
 )
 val ossrhPassword by extra(
-    localProps.getOrDefault("ossrhPassword", System.getenv("OSSRH_PASSWORD") ?: "")
+    localProps.getOrDefault("ossrhPassword", System.getenv("OSSRH_PASSWORD") ?: ""),
 )
 val sonatypeStagingProfileId by extra(
     localProps.getOrDefault(
         "sonatypeStagingProfileId",
-        System.getenv("SONATYPE_STAGING_PROFILE_ID") ?: ""
-    )
+        System.getenv("SONATYPE_STAGING_PROFILE_ID") ?: "",
+    ),
 )
 
 nexusPublishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,12 +19,12 @@ webrtc-ios-sdk = "125.6422.07"
 
 #Android
 minSdk = "21"
-compileSdk = "36"
-targetSdk = "36"
+compileSdk = "35"
+targetSdk = "35"
 
 # Plugins
-agp = "8.10.0"
-ktlint = "10.3.0"
+agp = "8.9.3"
+ktlint = "12.2.0"
 nexus = "1.3.0"
 compose-plugin = "1.7.3"
 


### PR DESCRIPTION
Downgraded AGP to v8.9.3 as v8.10.0 is not supported by Intellij Idea yet.
Also Android compile SDK version is set to the latest stable API level (35).