### PR TITLE
fix(js): handle text and binary in DataChannel MessageEvent.data

### DIFF
--- a/webrtc-kmp/src/wasmJsMain/kotlin/com/shepeliev/webrtckmp/externals/RTCDataChannel.wasmJs.kt
+++ b/webrtc-kmp/src/wasmJsMain/kotlin/com/shepeliev/webrtckmp/externals/RTCDataChannel.wasmJs.kt
@@ -5,10 +5,13 @@ import org.khronos.webgl.Int8Array
 import org.khronos.webgl.get
 import org.khronos.webgl.set
 
+/** Returns MessageEvent.data as Int8Array. Handles both string (TextEncoder) and ArrayBuffer. */
+private fun messageEventDataToInt8Array(ev: WasmMessageEvent): Int8Array = js("(function(e){var d=e.data;if(typeof d==='string')return new Int8Array(new TextEncoder().encode(d).buffer);return new Int8Array(d);})(ev)")
+
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 internal actual val MessageEvent.data: ByteArray
     get() {
-        val jsArray = Int8Array((this as WasmMessageEvent).data)
+        val jsArray = messageEventDataToInt8Array(this as WasmMessageEvent)
         return ByteArray(jsArray.length) { jsArray[it] }
     }
 


### PR DESCRIPTION
Context: https://github.com/shepeliev/webrtc-kmp/issues/189

After raising this GHI, I wanted to see if I could fix the issue and verify it locally. I was successfully able to fork the repo, apply the fix and publish a test build via GitHub Packages. After testing this fix, I was able to verify that when receiving payloads which were emitted as raw strings (from our backend servers), I was able to receive them (formed correctly) via this library.

This would indicate that the analysis from Cursor (in the GHI) is pretty accurate. We should be careful when converting the WasmMessageEvent's data into an Int8Array. If the data is actually of a String type, we need to encode it correctly. If we don't, the automatic conversion fails and we receive an empty buffer.

While I was able to test this fix for WASM, I don't have a good way to test the (Cursor) suggested for the JS variant and therefore chose not to include it. It's very possible (likely) though that it has a similar issue.

Thanks for the library, it's been incredibly useful!